### PR TITLE
refactor: 소셜 로그인 관련 파일 구조 변경 및 service명 변경

### DIFF
--- a/src/main/java/com/Alchive/backend/config/auth/SecurityConfig.java
+++ b/src/main/java/com/Alchive/backend/config/auth/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.Alchive.backend.config.auth;
 
+import com.Alchive.backend.config.auth.handler.OAuth2FailureHandler;
+import com.Alchive.backend.config.auth.handler.OAuth2SuccessHandler;
+import com.Alchive.backend.config.auth.service.CustomOAuth2UserService;
 import com.Alchive.backend.config.jwt.JwtAuthFilter;
 import com.Alchive.backend.config.jwt.TokenService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/Alchive/backend/config/auth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/Alchive/backend/config/auth/handler/OAuth2FailureHandler.java
@@ -1,4 +1,4 @@
-package com.Alchive.backend.config.auth;
+package com.Alchive.backend.config.auth.handler;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/Alchive/backend/config/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/Alchive/backend/config/auth/handler/OAuth2SuccessHandler.java
@@ -1,4 +1,4 @@
-package com.Alchive.backend.config.auth;
+package com.Alchive.backend.config.auth.handler;
 
 import com.Alchive.backend.config.jwt.TokenService;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/Alchive/backend/config/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/Alchive/backend/config/auth/service/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package com.Alchive.backend.config.auth;
+package com.Alchive.backend.config.auth.service;
 
 import com.Alchive.backend.config.auth.dto.OAuth2Attributes;
 import com.Alchive.backend.domain.User;
@@ -50,8 +50,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private User saveOrUpdate(OAuth2Attributes attributes) {
         User user = userRepository.findByUserEmail(attributes.getEmail())
-                // 구글 사용자 정보 업데이트(이미 가입된 사용자) => 업데이트
-                .map(entity -> entity.update(attributes.getName()))
                 // 가입되지 않은 사용자 => User 엔티티 생성
                 .orElse(attributes.toEntity());
         // 생성해서 DB에 등록(회원가입)

--- a/src/main/java/com/Alchive/backend/controller/UserController.java
+++ b/src/main/java/com/Alchive/backend/controller/UserController.java
@@ -4,7 +4,7 @@ import com.Alchive.backend.domain.User;
 import com.Alchive.backend.dto.request.UserUpdateRequest;
 import com.Alchive.backend.dto.response.ApiResponse;
 import com.Alchive.backend.dto.response.UserDetailData;
-import com.Alchive.backend.service.UserDetailService;
+import com.Alchive.backend.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,18 +13,18 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 public class UserController {
-    private final UserDetailService userDetailService;
+    private final UserService userService;
 
     @GetMapping("/api/v1/users/{userId}")
     public ResponseEntity<ApiResponse> findUser(@PathVariable Long userId) {
-        User user = userDetailService.getUserDetail(userId);
+        User user = userService.getUserDetail(userId);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "유저 정보를 불러왔습니다. ", new UserDetailData(user)));
     }
 
     @PutMapping("/api/v1/users/{userId}")
     public ResponseEntity<ApiResponse> updateUser(@PathVariable Long userId, @RequestBody UserUpdateRequest request) {
-        userDetailService.updateUserDetail(userId, request);
+        userService.updateUserDetail(userId, request);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "프로필 수정이 완료되었습니다. ", null));
     }

--- a/src/main/java/com/Alchive/backend/service/UserService.java
+++ b/src/main/java/com/Alchive/backend/service/UserService.java
@@ -1,21 +1,17 @@
 package com.Alchive.backend.service;
 
 import com.Alchive.backend.config.Code;
-import com.Alchive.backend.config.ErrorCode;
 import com.Alchive.backend.config.GeneralException;
 import com.Alchive.backend.domain.User;
 import com.Alchive.backend.dto.request.UserUpdateRequest;
 import com.Alchive.backend.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-
-import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
 @Service
-public class UserDetailService {
+public class UserService {
     private final UserRepository userRepository;
 
     public User getUserDetail(Long userId) {


### PR DESCRIPTION
## Summary

<!-- 작업한 내용을 간단히 작성해주세요. -->
소셜 로그인 관련 파일 구조 변경 및 service명 변경
+ 구글 닉네임 자동 저장 기능 삭제

## Description

<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->

- auth 패키지의 파일 구조 정리
- 소셜 로그인 시 구글 닉네임으로 항상 업데이트 되는 기능 삭제
- UserDetailService를 UserService로 변경

## Screenshot

<!-- 실행 결과 스크린샷을 올려주세요. -->

- 변경된 파일구조
<img width="281" alt="스크린샷 2024-03-29 오후 12 29 22" src="https://github.com/Alchive-grad-work/backend/assets/94193594/1606d087-75fe-4de5-8eba-77f438e3198e">


## Test Checklist

<!-- 확인해야 할 체크리스트를 작성해주세요. -->

- [ ] 체크리스트
