### PR TITLE
feat: user API 요청 방식 토큰으로 변경

### DIFF
--- a/src/main/java/com/Alchive/backend/controller/UserController.java
+++ b/src/main/java/com/Alchive/backend/controller/UserController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -49,17 +50,17 @@ public class UserController {
     }
 
     @Operation(summary = "프로필 수정 메서드", description = "특정 사용자의 프로필 정보를 수정하는 메서드입니다. ")
-    @PutMapping("/{userId}")
-    public ResponseEntity<ApiResponse> updateUser(@PathVariable Long userId, @RequestBody UserUpdateRequest request) {
-        userService.updateUserDetail(userId, request);
+    @PutMapping("/")
+    public ResponseEntity<ApiResponse> updateUser(HttpServletRequest request, @RequestBody UserUpdateRequest updateRequest) {
+        userService.updateUserDetail(request, updateRequest);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "사용자 프로필 수정이 완료되었습니다."));
     }
 
     @Operation(summary = "사용자 정보 삭제 메서드", description = "특정 사용자 정보를 삭제하는 메서드입니다. ")
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<ApiResponse> deleteUser(@PathVariable Long userId) {
-        userService.deleteUserDetail(userId);
+    @DeleteMapping("/")
+    public ResponseEntity<ApiResponse> deleteUser(HttpServletRequest request) {
+        userService.deleteUserDetail(request);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(),"유저 정보를 삭제했습니다. "));
     }

--- a/src/main/java/com/Alchive/backend/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/Alchive/backend/dto/response/UserResponseDTO.java
@@ -10,10 +10,14 @@ public class UserResponseDTO {
     private Long userId;
     private String userEmail;
     private String userName;
+    private String accessToken;
+    private String refreshToken;
 
-    public UserResponseDTO(User user) {
+    public UserResponseDTO(User user, String accessToken, String refreshToken) {
         this.userId=user.getUserId();
         this.userEmail=user.getUserEmail();
         this.userName=user.getUserName();
+        this.accessToken=accessToken;
+        this.refreshToken=refreshToken;
     }
 }

--- a/src/main/java/com/Alchive/backend/service/UserService.java
+++ b/src/main/java/com/Alchive/backend/service/UserService.java
@@ -51,14 +51,18 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserDetail(Long userId, UserUpdateRequest request) {
+    public void updateUserDetail(HttpServletRequest request, UserUpdateRequest updateRequest) {
+        tokenService.validateAccessToken(tokenService.resolveAccessToken(request));
+        Long userId = tokenService.getUserIdFromToken(request);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchIdException(Code.USER_NOT_FOUND, userId));
-        user.update(request.getUserDescription(), request.getAutoSave());
+        user.update(updateRequest.getUserDescription(), updateRequest.getAutoSave());
     }
 
     @Transactional
-    public void deleteUserDetail(Long userId) {
+    public void deleteUserDetail(HttpServletRequest request) {
+        tokenService.validateAccessToken(tokenService.resolveAccessToken(request));
+        Long userId = tokenService.getUserIdFromToken(request);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchIdException(Code.USER_NOT_FOUND, userId));
         userRepository.delete(user);

--- a/src/main/java/com/Alchive/backend/service/UserService.java
+++ b/src/main/java/com/Alchive/backend/service/UserService.java
@@ -22,6 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final TokenService tokenService;
 
+    @Transactional
     public UserResponseDTO createUser(UserCreateRequest request) {
         String email = request.getUserEmail();
         String username = request.getUserName();
@@ -34,7 +35,12 @@ public class UserService {
 
         User user = new User(email,username);
         user = userRepository.save(user); // db에 유저 저장 - 회원 가입
-        return new UserResponseDTO(user);
+
+        // 토큰 생성 후 전달
+        Long userId = user.getUserId();
+        String accessToken = tokenService.generateAccessToken(userId);
+        String refreshToken = tokenService.generateRefreshToken(userId);
+        return new UserResponseDTO(user,accessToken,refreshToken);
     }
 
     public void isDuplicateUsername(String userName) {
@@ -43,26 +49,26 @@ public class UserService {
         }
     }
 
-    public User getUserDetail(HttpServletRequest request) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(request));
-        Long userId = tokenService.getUserIdFromToken(request);
+    public User getUserDetail(HttpServletRequest tokenRequest) {
+        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest));
+        Long userId = tokenService.getUserIdFromToken(tokenRequest);
         return userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchIdException(Code.USER_NOT_FOUND, userId));
     }
 
     @Transactional
-    public void updateUserDetail(HttpServletRequest request, UserUpdateRequest updateRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(request));
-        Long userId = tokenService.getUserIdFromToken(request);
+    public void updateUserDetail(HttpServletRequest tokenRequest, UserUpdateRequest updateRequest) {
+        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest));
+        Long userId = tokenService.getUserIdFromToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchIdException(Code.USER_NOT_FOUND, userId));
         user.update(updateRequest.getUserDescription(), updateRequest.getAutoSave());
     }
 
     @Transactional
-    public void deleteUserDetail(HttpServletRequest request) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(request));
-        Long userId = tokenService.getUserIdFromToken(request);
+    public void deleteUserDetail(HttpServletRequest tokenRequest) {
+        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest));
+        Long userId = tokenService.getUserIdFromToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchIdException(Code.USER_NOT_FOUND, userId));
         userRepository.delete(user);


### PR DESCRIPTION
## Summary

<!-- 작업한 내용을 간단히 작성해주세요. -->
User 관련 API 요청 시 토큰을 사용하도록 수정
## Description

<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->
- UserService 수정: updateUser, deleteUser
    - Long userId → HttpServletRequest request로 매개변수 변경
- UserController 수정: updateUserDetail, deleteUserDetail
    - request에서 토큰 디코딩/검증/정보 추출 과정 추가
## Screenshot

<!-- 실행 결과 스크린샷을 올려주세요. -->

- 기존 user 테이블
    
    <img width="599" alt="스크린샷 2024-04-18 오전 11 40 13" src="https://github.com/Alchive-grad-work/backend/assets/96415630/8113312d-3e59-4dfa-b7ee-8944fdc5bf13">

    
- 수정 요청 전송, 리프레시/액세스 토큰 검증 후 문제 없다면 요청 수행
    
    <img width="847" alt="스크린샷 2024-04-18 오전 11 40 31" src="https://github.com/Alchive-grad-work/backend/assets/96415630/643870eb-bdb1-418b-879d-940ce487ecb6">

    
- 변경된 user 테이블
    <img width="600" alt="스크린샷 2024-04-18 오전 11 40 44" src="https://github.com/Alchive-grad-work/backend/assets/96415630/4b377332-8167-45b3-92e9-753044ce4fad">

    
## Test Checklist
<!-- 확인해야 할 체크리스트를 작성해주세요. -->


## 2024.4.19 변경&추가사항
- UserService
  - request를 tokenRequest로 변경
  - createUser: 액세스/리프레시 토큰 발급 로직 추가, UserResponseDTO에 토큰 전달
- DTO > response
  - UserResponseDTO: 액세스/리프레시 토큰 필드 추가

## Screenshot
- 스웨거에서 회원가입 요청
  <img width="860" alt="스크린샷 2024-04-19 오전 10 33 38" src="https://github.com/Alchive-grad-work/backend/assets/96415630/25df5297-5c92-4b4a-b5a2-6aa11dd4cd46">
- 회원가입 완료, 토큰 발급
  <img width="740" alt="스크린샷 2024-04-19 오전 10 33 54" src="https://github.com/Alchive-grad-work/backend/assets/96415630/c9e43788-320e-4101-8569-b9cf8ca4eca0">
- User 테이블에서 회원가입 확인 가능
  <img width="646" alt="스크린샷 2024-04-19 오전 10 34 09" src="https://github.com/Alchive-grad-work/backend/assets/96415630/db4277f7-1be4-4157-97ef-08f555fe96f3">
- 스웨거에서 추가된 사용자 확인 가능
  <img width="838" alt="스크린샷 2024-04-19 오전 10 35 07" src="https://github.com/Alchive-grad-work/backend/assets/96415630/75b560d8-ceaf-4fa3-9bff-cf462e1c8522">

  