### PR TITLE
feat: problem API 요청 방식 토큰으로 변경

### DIFF
--- a/src/main/java/com/Alchive/backend/config/Code.java
+++ b/src/main/java/com/Alchive/backend/config/Code.java
@@ -22,6 +22,7 @@ public enum Code implements ErrorCode {
     // PROBLEM
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "문제를 불러오는 데 실패했습니다. [problem: "),
     PROBLEM_CREATED(HttpStatus.CREATED.value(), "문제가 생성되었습니다. [problem: "),
+    PROBLEM_USER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "해당 문제의 작성자가 아닙니다. [problem: "),
     PLATFORM_INVALID(HttpStatus.NOT_FOUND.value(), "지원하지 않는 플랫폼입니다. [platform: "),
 
     // SEARCH

--- a/src/main/java/com/Alchive/backend/config/jwt/TokenService.java
+++ b/src/main/java/com/Alchive/backend/config/jwt/TokenService.java
@@ -1,8 +1,10 @@
 package com.Alchive.backend.config.jwt;
 
 import com.Alchive.backend.config.Code;
+import com.Alchive.backend.config.exception.NoSuchIdException;
 import com.Alchive.backend.config.exception.TokenExpiredException;
 import com.Alchive.backend.config.exception.TokenNotFoundException;
+import com.Alchive.backend.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -29,6 +31,12 @@ public class TokenService {
     private Long ACCESS_EXPIRE_LENGTH;
     @Value("${jwt.token.refresh-expire-length}")
     private Long REFRESH_EXPIRE_LENGTH;
+
+    private final UserRepository userRepository;
+
+    public TokenService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @PostConstruct
     protected void init() {
@@ -119,8 +127,11 @@ public class TokenService {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+        Long userId = Long.parseLong(claims.getSubject());
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchIdException(Code.USER_NOT_FOUND, userId));
 
-        return Long.parseLong(claims.getSubject());
+        return userId;
     }
 
     public String getEmail(String token) {

--- a/src/main/java/com/Alchive/backend/controller/ProblemController.java
+++ b/src/main/java/com/Alchive/backend/controller/ProblemController.java
@@ -10,6 +10,7 @@ import com.Alchive.backend.service.ProblemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -17,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -35,21 +35,9 @@ public class ProblemController {
     @Operation(summary = "미제출 문제 저장 메서드", description = "코드 없이 문제 설명 페이지에서 가져온 문제 정보만을 저장하는 메서드입니다.")
     @PostMapping
     public ResponseEntity<ApiResponse> createProblem(
-            @RequestParam Long userId,
-            @RequestBody @Valid ProblemCreateRequest request, BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            log.error("valide error");
-            StringBuilder sb = new StringBuilder();
-            bindingResult.getAllErrors().forEach(objectError -> {
-                FieldError field = (FieldError) objectError;
-                String message = objectError.getDefaultMessage();
-                sb.append("field :" + field.getField());
-                sb.append("message :" + message);
-            });
-            log.error(sb.toString());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse(HttpStatus.BAD_REQUEST.value(), sb.toString()));
-        }
-        problemService.createProblem(userId, request);
+            HttpServletRequest tokenRequest,
+            @RequestBody @Valid ProblemCreateRequest problemRequest, BindingResult bindingResult) {
+        problemService.createProblem(tokenRequest, problemRequest);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "미제출 문제 정보를 저장했습니다."));
     }
@@ -57,17 +45,17 @@ public class ProblemController {
     @Operation(summary = "제출 후(맞/틀) 문제 저장 메서드", description = "코드 제출 후 문제 정보와 정답 여부, 코드 정보를 저장하는 메서드입니다.")
     @PostMapping("/submit")
     public ResponseEntity<ApiResponse> createProblemSubmit(
-            @RequestParam Long userId,
-            @RequestBody @Valid SubmitProblemCreateRequest request) {
-        problemService.createProblemSubmit(userId, request);
+            HttpServletRequest tokenRequest,
+            @RequestBody @Valid SubmitProblemCreateRequest problemRequest) {
+        problemService.createProblemSubmit(tokenRequest, problemRequest);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "제출한 문제와 코드 정보를 저장했습니다."));
     }
 
     @Operation(summary = "문제 저장 여부 검사 메서드", description = "문제 번호를 이용해 저장된 문제인지를 검사하는 메서드입니다.")
     @GetMapping("/check/{problemNumber}")
-    public ResponseEntity<ApiResponse> checkProblem(@RequestParam Long userId, @PathVariable int problemNumber, @RequestParam String platform) {
-        if (problemService.checkProblem(userId, problemNumber, platform)) { // 존재하는 경우
+    public ResponseEntity<ApiResponse> checkProblem(HttpServletRequest tokenRequest, @PathVariable int problemNumber, @RequestParam String platform) {
+        if (problemService.checkProblem(tokenRequest, problemNumber, platform)) { // 존재하는 경우
             return ResponseEntity.ok()
                     .body(new ApiResponse(HttpStatus.OK.value(), "저장된 문제입니다."));
         } else {
@@ -78,11 +66,10 @@ public class ProblemController {
     @Operation(summary = "플랫폼 별 문제 목록 조회 메서드", description = "특정 플랫폼에 해당하는 문제 목록을 조회하는 메서드입니다.")
     @GetMapping("/platform")
     public ResponseEntity<ApiResponse> getProblemPlatform(
-            @RequestParam(required = true, name = "id") @Schema(description = "사용자 아이디")
-            Long userId,
+            HttpServletRequest tokenRequest,
             @RequestParam(required = true, name = "p") @Schema(description = "Algorithm Platform")
             String platform) {
-        List<ProblemListResponseDTO> problemData = problemService.getProblemsByPlatform(userId, platform);
+        List<ProblemListResponseDTO> problemData = problemService.getProblemsByPlatform(tokenRequest, platform);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "플랫폼 별 문제 목록을 불러왔습니다.", problemData));
     }
@@ -90,30 +77,29 @@ public class ProblemController {
     @Operation(summary = "문제 검색 메서드", description = "특정 키워드에 대한 문제를 검색하는 메서드입니다. ")
     @GetMapping("/search")
     public ResponseEntity<ApiResponse> getProblemSearch(
-            @RequestParam(required = true, name = "id") @Schema(description = "사용자 아이디")
-            Long userId,
+            HttpServletRequest tokenRequest,
             @RequestParam(required = true, name = "k") @Schema(description = "검색 내용")
             String keyword,
             @RequestParam(required = false, name = "c") @Schema(description = "카테고리")
             String category
             ) {
-        List<ProblemListResponseDTO> problemData = problemService.getProblemsSearch(userId, keyword, category);
+        List<ProblemListResponseDTO> problemData = problemService.getProblemsSearch(tokenRequest, keyword, category);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "검색 결과를 불러왔습니다.", problemData));
     }
 
     @Operation(summary = "문제 목록 조회 메서드", description = "문제 목록을 조회하는 메서드입니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse> getProblemsByUserId(@RequestParam Long userId) {
-        List<ProblemListResponseDTO> problemData = problemService.getProblemsByUserId(userId);
+    public ResponseEntity<ApiResponse> getProblemsByUserId(HttpServletRequest tokenRequest) {
+        List<ProblemListResponseDTO> problemData = problemService.getProblemsByUserId(tokenRequest);
         return ResponseEntity.ok()
                 .body(new ApiResponse(HttpStatus.OK.value(), "문제 목록을 불러왔습니다.", problemData));
     }
 
     @Operation(summary = "문제 삭제 메서드", description = "문제 정보를 삭제하는 메서드입니다. ")
     @DeleteMapping("/{problemId}")
-    public ResponseEntity<ApiResponse> deleteProblem(@PathVariable Long problemId) {
-        problemService.deleteProblem(problemId);
+    public ResponseEntity<ApiResponse> deleteProblem(HttpServletRequest tokenRequest, @PathVariable Long problemId) {
+        problemService.deleteProblem(tokenRequest, problemId);
         return ResponseEntity.ok()
                 .body(new ApiResponse((HttpStatus.OK.value()),"문제를 삭제했습니다. "));
     }


### PR DESCRIPTION
## Summary

<!-- 작업한 내용을 간단히 작성해주세요. -->

problem API 요청 방식 토큰으로 변경

## Description

<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->

- 문제 컨트롤러와 서비스에서 requestParam으로 받던 UserId를 HttpServletRequest을 사용해 받아온 토큰에서 사용하는 방식으로 변경
    - 기존의 로직을 건드리지 않고 만료 검사 처리 및 userID를 꺼내오는 로직을 추가해 구현했음
- * 문제 서비스의 문제 삭제 기능에서 받아온 userId와 problemId로 해당 유저가 작성자인지 확인하는 코드 추가
- * 문제 생성 컨트롤러에서 bindingresult 삭제
- 토큰 서비스의 토큰에서 유저 아이디를 가져오는 기능에서 토큰에서 아이디를 꺼낸 뒤 그 유저가 db에 실제로 존재하는지 확인 및 에러 처리 추가

## Screenshot

<!-- 실행 결과 스크린샷을 올려주세요. -->
- 공통 변경 사항 (토큰이 없을 경우)
<img width="1407" alt="스크린샷 2024-04-19 오전 12 03 10" src="https://github.com/Alchive-grad-work/backend/assets/94193594/51159749-7a2f-40d5-ac1e-d6a7d35850f6">

- 문제 삭제 시 해당 유저가 작성자가 아닌 경우 에러 처리
<img width="1418" alt="스크린샷 2024-04-18 오후 11 41 04" src="https://github.com/Alchive-grad-work/backend/assets/94193594/57c82900-e356-464d-ad90-7a20d0bc7f57">


## Test Checklist

<!-- 확인해야 할 체크리스트를 작성해주세요. -->

- [ ] 추후 단일 문제 조회, 문제 메모 수정 API도 수정 예정
