### PR TITLE
refactor: 액세스 토큰에서 userId 추출하도록 변경

### DIFF
--- a/src/main/java/com/Alchive/backend/config/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/Alchive/backend/config/auth/handler/OAuth2SuccessHandler.java
@@ -37,7 +37,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if ( user.isPresent() ) { // 로그인인 경우
             userId = user.get().getUserId();
             String accessToken = tokenService.generateAccessToken(userId);
-            String refreshToken = tokenService.generateRefreshToken(userId);
+            String refreshToken = tokenService.generateRefreshToken();
             targetUrl = UriComponentsBuilder.fromUriString("/")
                     .queryParam("access", accessToken)
                     .queryParam("refresh", refreshToken)

--- a/src/main/java/com/Alchive/backend/config/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/Alchive/backend/config/error/GlobalExceptionHandler.java
@@ -1,20 +1,23 @@
 package com.Alchive.backend.config.error;
 
 import com.Alchive.backend.config.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception) {
+        log.info(exception.getMessage() + ", " + exception.getClass());
         ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
                         .code(String.valueOf(errorCode.getCode()))
-                        .message(errorCode.getMessage())
+                        .message(errorCode.getMessage() + ": " + exception.getClass())
                         .build());
     }
     @ExceptionHandler(BusinessException.class)

--- a/src/main/java/com/Alchive/backend/config/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/Alchive/backend/config/error/GlobalExceptionHandler.java
@@ -8,6 +8,15 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        ErrorCode errorCode = ErrorCode._INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ErrorResponse.builder()
+                        .code(String.valueOf(errorCode.getCode()))
+                        .message(errorCode.getMessage())
+                        .build());
+    }
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<Object> handleRuntimeException(BusinessException exception) {
         ErrorCode errorCode = exception.getErrorCode();

--- a/src/main/java/com/Alchive/backend/config/error/exception/BusinessException.java
+++ b/src/main/java/com/Alchive/backend/config/error/exception/BusinessException.java
@@ -7,37 +7,10 @@ import lombok.Getter;
 public class BusinessException extends RuntimeException{
     private final ErrorCode errorCode;
     private final String message;
-//    private final String paramType1;
-//    private final Object param1;
-//    private String paramType2 = null;
-//    private Object param2 = null;
 
     public BusinessException(ErrorCode errorCode, String message) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.message = message;
     }
-//    public BusinessException(ErrorCode errorCode, String paramType, Object param) {
-//        super(errorCode.getMessage());
-//        this.errorCode = errorCode;
-//        this.paramType1 = paramType;
-//        this.param1 = param;
-//    }
-//
-//    public BusinessException(ErrorCode errorCode, String paramType1, Object param1, Object param2) {
-//        super(errorCode.getMessage());
-//        this.errorCode = errorCode;
-//        this.paramType1 = paramType1;
-//        this.param1 = param1;
-//        this.param2 = param2;
-//    }
-//
-//    public BusinessException(ErrorCode errorCode, String paramType1, Object param1, String  paramType2, Object param2) {
-//        super(errorCode.getMessage());
-//        this.errorCode = errorCode;
-//        this.paramType1 = paramType1;
-//        this.param1 = param1;
-//        this.paramType2 = paramType2;
-//        this.param2 = param2;
-//    }
 }

--- a/src/main/java/com/Alchive/backend/config/error/exception/token/TokenExpiredException.java
+++ b/src/main/java/com/Alchive/backend/config/error/exception/token/TokenExpiredException.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class TokenExpiredException extends BusinessException {
-    public TokenExpiredException(String tokenType, String token) {
-        super(ErrorCode.TOKEN_EXPIRED, " - " + tokenType + ": " + token);
+    public TokenExpiredException(String tokenType) {
+        super(ErrorCode.TOKEN_EXPIRED, " - " + tokenType);
     }
 }

--- a/src/main/java/com/Alchive/backend/config/jwt/TokenService.java
+++ b/src/main/java/com/Alchive/backend/config/jwt/TokenService.java
@@ -4,20 +4,19 @@ import com.Alchive.backend.config.error.exception.user.NoSuchUserIdException;
 import com.Alchive.backend.config.error.exception.token.TokenExpiredException;
 import com.Alchive.backend.config.error.exception.token.TokenNotExistsException;
 import com.Alchive.backend.repository.UserRepository;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
 
+@Slf4j
 @Service
 public class TokenService {
     // JWT 토큰 생성
@@ -53,16 +52,16 @@ public class TokenService {
     }
 
     public String generateRefreshToken(Long userId) {
-        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
-        return Jwts.builder().setClaims(claims)
+        return Jwts.builder()
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRE_LENGTH))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public boolean validateAccessToken(String token) {
+    public boolean validateAccessToken(HttpServletRequest request) {
         try {
+            String token = resolveAccessToken(request);
             Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey)
                     .build().parseClaimsJws(token);
 
@@ -70,12 +69,13 @@ public class TokenService {
                     .after(new Date(System.currentTimeMillis()));
 
         } catch (Exception e) {
-            throw new TokenExpiredException("access token", token);
+            throw new TokenExpiredException("access token");
         }
     }
 
-    public boolean validateRefreshToken(String token) {
+    public boolean validateRefreshToken(HttpServletRequest request) {
         try {
+            String token = resolveRefreshToken(request);
             Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey)
                     .build().parseClaimsJws(token);
 
@@ -83,7 +83,7 @@ public class TokenService {
                     .after(new Date(System.currentTimeMillis()));
 
         } catch (Exception e) {
-            throw new TokenExpiredException("refresh token", token);
+            throw new TokenExpiredException("refresh token");
         }
     }
 
@@ -108,34 +108,34 @@ public class TokenService {
 
     // 리프레시 토큰으로 새로운 액세스 토큰 발급
     public String refreshAccessToken(HttpServletRequest request) {
-        String accessToken;
         String refreshToken = resolveRefreshToken(request);
-        if (refreshToken == null ) { // 리프레시 토큰이 만료된 경우
-            throw new TokenExpiredException("refresh token", refreshToken);
+        if (refreshToken == null ) { // 리프레시 토큰이 없는 경우
+            throw new TokenNotExistsException("refresh token");
         }
-        validateRefreshToken(refreshToken); // 리프레시 토큰 검증
+        validateRefreshToken(request); // 리프레시 토큰 검증
         Long userId = getUserIdFromToken(request);
-        accessToken = generateAccessToken(userId);
+        String accessToken = generateAccessToken(userId);
         return accessToken;
     }
 
     public Long getUserIdFromToken(HttpServletRequest request) { // 토큰에서 userId 정보 꺼내기
-        String token = resolveRefreshToken(request);
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-        Long userId = Long.parseLong(claims.getSubject());
-        userRepository.findById(userId)
-                .orElseThrow(() -> new NoSuchUserIdException(userId));
-
-        return userId;
-    }
-
-    public String getEmail(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build().parseClaimsJws(token).getBody().getSubject();
+        String token = resolveAccessToken(request);
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            Long userId = Long.parseLong(claims.getSubject());
+            userRepository.findById(userId)
+                    .orElseThrow(() -> new NoSuchUserIdException(userId)); // user 검증
+            return userId;
+        } catch ( ExpiredJwtException exception ) {
+            Claims expiredClaims = exception.getClaims();
+            Long userId = Long.parseLong(expiredClaims.getSubject());
+            userRepository.findById(userId)
+                    .orElseThrow(() -> new NoSuchUserIdException(userId)); // user 검증
+            return userId;
+        }
     }
 }

--- a/src/main/java/com/Alchive/backend/service/ProblemService.java
+++ b/src/main/java/com/Alchive/backend/service/ProblemService.java
@@ -39,7 +39,7 @@ public class ProblemService {
     // 미제출 문제 저장
     @Transactional
     public void createProblem(HttpServletRequest tokenRequest, ProblemCreateRequest problemRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchUserIdException(userId));
@@ -57,7 +57,7 @@ public class ProblemService {
 
     // 맞/틀 문제 저장
     public void createProblemSubmit(HttpServletRequest tokenRequest, ProblemCreateRequest problemRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchUserIdException(userId));
@@ -83,7 +83,7 @@ public class ProblemService {
 
     // 문제 저장 여부 검사
     public boolean checkProblem(HttpServletRequest tokenRequest, int problemNumber, String platform) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         Problem problem = problemRepository.findByUserUserIdAndProblemNumberAndProblemPlatform(userId, problemNumber, platform);
         return problem != null;
@@ -92,7 +92,7 @@ public class ProblemService {
 
     // 플랫폼 별 조회
     public List<ProblemListResponseDTO> getProblemsByPlatform(HttpServletRequest tokenRequest, String platform) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         // Baekjoon, Programmers, Leetcode가 아닌 경우
         if (!platform.equals("Baekjoon") && !platform.equals("Programmers") && !platform.equals("Leetcode")) {
@@ -106,7 +106,7 @@ public class ProblemService {
 
     // 문제 검색
     public List<ProblemListResponseDTO> getProblemsSearch(HttpServletRequest tokenRequest, String keyword, String category) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         List<Problem> problems;
         if (category == null) {
@@ -123,7 +123,7 @@ public class ProblemService {
 
     // 사용자가 작성한 전체 목록 조회
     public List<ProblemListResponseDTO> getProblemsByUserId(HttpServletRequest tokenRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         List<Problem> userProblems = problemRepository.findByUserUserId(userId);
         if (!userRepository.existsByUserId(userId)) {
@@ -146,7 +146,7 @@ public class ProblemService {
     // 문제 삭제
     @Transactional
     public void deleteProblem(HttpServletRequest tokenRequest, Long problemId) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         Problem problem = problemRepository.findById(problemId)
                         .orElseThrow(() -> new NoSuchProblemIdException(problemId));
@@ -175,7 +175,7 @@ public class ProblemService {
     // 문제 메모 수정
     @Transactional
     public void updateProblemMemo(HttpServletRequest tokenRequest, ProblemMemoUpdateRequest memoRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest)); // 만료 검사
+        tokenService.validateAccessToken(tokenRequest); // 만료 검사
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         Problem problem = problemRepository.findById(memoRequest.getProblemId())
                 .orElseThrow(() -> new NoSuchProblemIdException(memoRequest.getProblemId()));

--- a/src/main/java/com/Alchive/backend/service/UserService.java
+++ b/src/main/java/com/Alchive/backend/service/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
         // 토큰 생성 후 전달
         Long userId = user.getUserId();
         String accessToken = tokenService.generateAccessToken(userId);
-        String refreshToken = tokenService.generateRefreshToken(userId);
+        String refreshToken = tokenService.generateRefreshToken();
         return new UserResponseDTO(user,accessToken,refreshToken);
     }
 

--- a/src/main/java/com/Alchive/backend/service/UserService.java
+++ b/src/main/java/com/Alchive/backend/service/UserService.java
@@ -46,7 +46,7 @@ public class UserService {
     }
 
     public User getUserDetail(HttpServletRequest tokenRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest));
+        tokenService.validateAccessToken(tokenRequest);
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         return userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchUserIdException(userId));
@@ -54,7 +54,7 @@ public class UserService {
 
     @Transactional
     public void updateUserDetail(HttpServletRequest tokenRequest, UserUpdateRequest updateRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest));
+        tokenService.validateAccessToken(tokenRequest);
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchUserIdException(userId));
@@ -63,7 +63,7 @@ public class UserService {
 
     @Transactional
     public void deleteUserDetail(HttpServletRequest tokenRequest) {
-        tokenService.validateAccessToken(tokenService.resolveAccessToken(tokenRequest));
+        tokenService.validateAccessToken(tokenRequest);
         Long userId = tokenService.getUserIdFromToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchUserIdException(userId));


### PR DESCRIPTION
## Summary

<!-- 작업한 내용을 간단히 작성해주세요. -->
- 리프레시 토큰 대신 엑세스 토큰에서 userId를 추출하도록 변경
- tokenService 메서드 일부 수정
## Description

<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->
- 리프레시 토큰에서 userId 제거
- 만료된 액세스 토큰에서 userId 추출 가능하도록 수정
- validateToken의 매개변수를 String token에서 HttpServletRequest request로 변경, validateToken 메서드 안에서 resolveToken을 호출하도록 수정
## Screenshot

<!-- 실행 결과 스크린샷을 올려주세요. -->
- 액세스 토큰 재발급 요청 시 성공 확인 가능
    <img width="748" alt="스크린샷 2024-04-29 오후 10 36 49" src="https://github.com/Alchive-grad-work/backend/assets/96415630/0b39d0a7-b278-41e7-a075-bc2f61fb418c">

    
- 리프레시 토큰에서 “sub” 필드 제거
    <img width="437" alt="스크린샷 2024-04-29 오후 10 38 19" src="https://github.com/Alchive-grad-work/backend/assets/96415630/4fcb8db5-588b-4bfb-a407-3f7f9134b6db">

    
## Test Checklist

<!-- 확인해야 할 체크리스트를 작성해주세요. -->

- [ ] 체크리스트
## 2024/4/30 추가 변경사항

- generateRefreshToken
    - 매개변수에서 userId 제거
- refreshAccessToken
    - 리프레시 토큰이 없는 경우를 확인하는 로직 제거(resolve와 중복됨)
- validateToken
    - try문에서 parseClaimsJws으로 만료 확인 → 현재 시간과 비교하는 로직 제거
    - 리턴 타입을 boolean에서 void로 변경
    
- **메서드별 책임 정리**
    - resolveToken
        - 역할: 헤더에서 토큰을 추출하고 반환
        - 예외 상황: 헤더에 토큰이 존재하지 않음
    - validateToken
        - 역할: 토큰의 만료 시간을 확인해서 만료 여부 확인
        - 예외 상황: 토큰이 만료됨
    
    **validateRefreshToken은 액세스 토큰 재발급(refreshAccessToken)에서만 사용**
    
    → refreshAccessToken에서 resolve로 토큰이 비어있지 않은지 확인, validate로 만료되지 않았는지 확인
- GlobalExceptionHandler
    - Exception class 처리 핸들러 추가(500 server error 처리)