### PR TITLE
refacotr: BaseEntity 도입 및 일부 코드 리팩토링

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,47 +38,47 @@ services:
   #    networks:
   #      - alchive
 
-  # Monitoring
-  prometheus:
-    container_name: prometheus
-    image: prom/prometheus:latest
-    volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-    ports:
-      - "9090:9090"
-    networks:
-      - alchive
-
-  grafana:
-    container_name: grafana
-    image: grafana/grafana:latest
-    volumes:
-      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
-      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
-      - ./monitoring/grafana/provisioning/dashboards:/var/lib/grafana/dashboards
-    ports:
-      - "3000:3000"
-    depends_on:
-      - prometheus
-    networks:
-      - alchive
-
-  cadvisor:
-    container_name: cadvisor
-    image: gcr.io/cadvisor/cadvisor:latest
-    ports:
-      - "8081:8081"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-    privileged: true
-    networks:
-      - alchive
+#  # Monitoring
+#  prometheus:
+#    container_name: prometheus
+#    image: prom/prometheus:latest
+#    volumes:
+#      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+#    command:
+#      - '--config.file=/etc/prometheus/prometheus.yml'
+#    ports:
+#      - "9090:9090"
+#    networks:
+#      - alchive
+#
+#  grafana:
+#    container_name: grafana
+#    image: grafana/grafana:latest
+#    volumes:
+#      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+#      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+#      - ./monitoring/grafana/provisioning/dashboards:/var/lib/grafana/dashboards
+#    ports:
+#      - "3000:3000"
+#    depends_on:
+#      - prometheus
+#    networks:
+#      - alchive
+#
+#  cadvisor:
+#    container_name: cadvisor
+#    image: gcr.io/cadvisor/cadvisor:latest
+#    ports:
+#      - "8081:8081"
+#    volumes:
+#      - /:/rootfs:ro
+#      - /var/run:/var/run:ro
+#      - /sys:/sys:ro
+#      - /var/lib/docker/:/var/lib/docker:ro
+#      - /var/run/docker.sock:/var/run/docker.sock
+#    privileged: true
+#    networks:
+#      - alchive
 
 networks:
   alchive:

--- a/src/main/java/com/Alchive/backend/BackendApplication.java
+++ b/src/main/java/com/Alchive/backend/BackendApplication.java
@@ -3,13 +3,15 @@ package com.Alchive.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @PropertySource("classpath:env.properties")
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BackendApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/Alchive/backend/config/DataInitializer.java
+++ b/src/main/java/com/Alchive/backend/config/DataInitializer.java
@@ -59,26 +59,26 @@ public class DataInitializer implements CommandLineRunner {
 
         // User 목업 데이터 생성
         User user1 = User.builder()
-                .userEmail("chohana@alchive.com")
-                .userNickName("조하나")
+                .email("chohana@alchive.com")
+                .name("조하나")
                 .build();
         userRepository.save(user1);
 
         User user2 = User.builder()
-                .userEmail("parknahyun@alchive.com")
-                .userNickName("박나현")
+                .email("parknahyun@alchive.com")
+                .name("박나현")
                 .build();
         userRepository.save(user2);
 
         User user3 = User.builder()
-                .userEmail("songyurim@alchive.com")
-                .userNickName("송유림")
+                .email("songyurim@alchive.com")
+                .name("송유림")
                 .build();
         userRepository.save(user3);
 
         User user4 = User.builder()
-                .userEmail("kimmiyoung@alchive.com")
-                .userNickName("김미영")
+                .email("kimmiyoung@alchive.com")
+                .name("김미영")
                 .build();
         userRepository.save(user4);
 

--- a/src/main/java/com/Alchive/backend/config/DataInitializer.java
+++ b/src/main/java/com/Alchive/backend/config/DataInitializer.java
@@ -112,7 +112,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("Hash Map을 사용하면 되지 않을까?")
                 .status(BoardStatus.INCORRECT)
                 .description("사용 알고리즘: **Hash Map**")
-                .createdAt(LocalDateTime.parse("2024-08-27T15:08:50"))
                 .build();
         boardRepository.save(board1);
 
@@ -286,7 +285,6 @@ public class DataInitializer implements CommandLineRunner {
                         "name과 yearning 매칭은 map 사용하거나 for문은 같은 인덱스 별로 묶어 계산<br>" +
                         "배열은 0부터 N까지 돌아가면서 탐색<br>" +
                         "map은 해당 key에 있는 value를 바로 가져온다 → 속도 빠름")
-                .createdAt(LocalDateTime.parse("2024-09-03T15:08:50"))
                 .build();
         boardRepository.save(board2);
 
@@ -372,7 +370,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("Two Pointer를 사용해보자")
                 .status(BoardStatus.INCORRECT)
                 .description("사용 알고리즘: Two Pointer")
-                .createdAt(LocalDateTime.parse("2024-09-16T15:08:50"))
                 .build();
         boardRepository.save(board3);
 
@@ -425,8 +422,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("큐와 우선순위 큐 개념 복습 필요")
                 .status(BoardStatus.COMPLETED)
                 .description("사용 알고리즘: Queue, Priority Queue")
-                .createdAt(LocalDateTime.parse("2024-09-17T22:08:50"))
-
                 .build();
         boardRepository.save(board4);
 
@@ -486,7 +481,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("작업 속도와 진도 계산 방법 이해 필요")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: Queue")
-                .createdAt(LocalDateTime.parse("2024-09-18T03:08:50"))
                 .build();
         boardRepository.save(board5);
 
@@ -546,7 +540,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("Stack 자료구조로 해결해보자")
                 .status(BoardStatus.INCORRECT)
                 .description("사용 알고리즘: Stack")
-                .createdAt(LocalDateTime.parse("2024-09-21T16:08:50"))
                 .build();
         boardRepository.save(board6);
 
@@ -594,7 +587,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("Dynamic Programming으로 해결 가능")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: Dynamic Programming")
-                .createdAt(LocalDateTime.parse("2024-10-01T15:08:50"))
                 .build();
         boardRepository.save(board7);
 
@@ -641,7 +633,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("2차원 배열에 대한 이해 필요")
                 .status(BoardStatus.COMPLETED)
                 .description("사용 알고리즘: Array")
-                .createdAt(LocalDateTime.parse("2024-10-02T15:08:50"))
                 .build();
         boardRepository.save(board8);
 
@@ -686,7 +677,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("DFS/BFS 재귀적으로 구현해보기")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: DFS, BFS")
-                .createdAt(LocalDateTime.parse("2024-10-08T15:08:50"))
                 .build();
         boardRepository.save(board9);
 
@@ -736,7 +726,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("완전탐색으로 해결 가능")
                 .status(BoardStatus.INCORRECT)
                 .description("사용 알고리즘: Brute Force")
-                .createdAt(LocalDateTime.parse("2024-10-10T15:08:50"))
                 .build();
         boardRepository.save(board10);
 
@@ -783,7 +772,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("이진 탐색을 통해 효율적으로 풀이 가능")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: Binary Search")
-                .createdAt(LocalDateTime.parse("2024-10-11T15:08:50"))
                 .build();
         boardRepository.save(board11);
 
@@ -833,7 +821,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("압축 단위별로 반복적으로 확인 필요")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: String Manipulation, Brute Force")
-                .createdAt(LocalDateTime.parse("2024-10-11T23:08:50"))
                 .build();
         boardRepository.save(board12);
 
@@ -889,7 +876,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("주어진 문자열 파싱과 순서 찾기 필요")
                 .status(BoardStatus.INCORRECT)
                 .description("사용 알고리즘: String Parsing, Set")
-                .createdAt(LocalDateTime.parse("2024-10-15T23:08:50"))
                 .build();
         boardRepository.save(board13);
 
@@ -940,7 +926,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("백트래킹을 이용해 조합 생성 필요")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: Backtracking, Set")
-                .createdAt(LocalDateTime.parse("2024-10-16T23:08:50"))
                 .build();
         boardRepository.save(board14);
 
@@ -1003,7 +988,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("좌표와 Set을 이용해 방문 체크 필요")
                 .status(BoardStatus.NOT_SUBMITTED)
                 .description("사용 알고리즘: Set, 2D Coordinates")
-                .createdAt(LocalDateTime.parse("2024-10-18T23:08:50"))
                 .build();
         boardRepository.save(board15);
 
@@ -1060,7 +1044,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("유일성과 최소성을 모두 만족하는 조합 찾기 필요")
                 .status(BoardStatus.COMPLETED)
                 .description("사용 알고리즘: Bit Masking, Set, Combination")
-                .createdAt(LocalDateTime.parse("2024-10-18T23:08:50"))
                 .build();
         boardRepository.save(board16);
 
@@ -1121,7 +1104,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("정규 표현식과 DFS/BFS를 통해 조합을 찾기")
                 .status(BoardStatus.INCORRECT)
                 .description("사용 알고리즘: DFS, Regex, Set")
-                .createdAt(LocalDateTime.parse("2024-10-20T23:08:50"))
                 .build();
         boardRepository.save(board17);
 
@@ -1178,7 +1160,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("2D 배열 회전과 이동 구현 필요")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: Array Manipulation, Brute Force")
-                .createdAt(LocalDateTime.parse("2024-10-22T23:08:50"))
                 .build();
         boardRepository.save(board18);
 
@@ -1250,7 +1231,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("최소 비용 신장 트리 문제")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: Kruskal's Algorithm, Union-Find")
-                .createdAt(LocalDateTime.parse("2024-10-22T23:08:50"))
                 .build();
         boardRepository.save(board19);
 
@@ -1314,7 +1294,6 @@ public class DataInitializer implements CommandLineRunner {
                 .memo("Map을 사용해 아이디와 닉네임을 추적")
                 .status(BoardStatus.CORRECT)
                 .description("사용 알고리즘: HashMap")
-                .createdAt(LocalDateTime.parse("2024-10-24T23:08:50"))
                 .build();
         boardRepository.save(board20);
 

--- a/src/main/java/com/Alchive/backend/config/auth/dto/OAuth2Attributes.java
+++ b/src/main/java/com/Alchive/backend/config/auth/dto/OAuth2Attributes.java
@@ -1,6 +1,5 @@
 package com.Alchive.backend.config.auth.dto;
 
-import com.Alchive.backend.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,8 +16,8 @@ public class OAuth2Attributes {
 
     @Builder
     public OAuth2Attributes(Map<String, Object> attributes,
-                           String nameAttributeKey, String name,
-                           String email, boolean isNewUser) {
+                            String nameAttributeKey, String name,
+                            String email, boolean isNewUser) {
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.name = name;
@@ -27,28 +26,20 @@ public class OAuth2Attributes {
 
     // OAuth2User에서 반환하는 사용자 정보는 Map. 따라서 값 하나하나를 변환해야함.
     public static OAuth2Attributes of(String registrationId,
-                                     String userNameAttributeName,
-                                     Map<String, Object> attributes) {
+                                      String userNameAttributeName,
+                                      Map<String, Object> attributes) {
 
         return ofGoogle(userNameAttributeName, attributes);
     }
 
     // 구글 생성자
     private static OAuth2Attributes ofGoogle(String usernameAttributeName,
-                                            Map<String, Object> attributes) {
+                                             Map<String, Object> attributes) {
         return OAuth2Attributes.builder()
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
                 .attributes(attributes)
                 .nameAttributeKey(usernameAttributeName)
-                .build();
-    }
-
-    // User 엔티티 생성
-    public User toEntity() {
-        return User.builder()
-                .userEmail(email)
-                .userNickName(name)
                 .build();
     }
 }

--- a/src/main/java/com/Alchive/backend/controller/BoardController.java
+++ b/src/main/java/com/Alchive/backend/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.Alchive.backend.controller;
 import com.Alchive.backend.config.result.ResultResponse;
 import com.Alchive.backend.dto.request.BoardCreateRequest;
 import com.Alchive.backend.dto.request.BoardMemoUpdateRequest;
+import com.Alchive.backend.dto.request.BoardUpdateRequest;
 import com.Alchive.backend.dto.request.ProblemNumberRequest;
 import com.Alchive.backend.dto.response.BoardDetailResponseDTO;
 import com.Alchive.backend.dto.response.BoardResponseDTO;
@@ -36,7 +37,6 @@ public class BoardController {
     public ResponseEntity<ResultResponse> isBoardSaved(HttpServletRequest tokenRequest, @RequestBody @Valid ProblemNumberRequest problemNumberRequest) {
         BoardDetailResponseDTO board = boardService.isBoardSaved(tokenRequest, problemNumberRequest);
         if (board != null) {
-            log.info(board.toString());
             return ResponseEntity.ok(ResultResponse.of(BOARD_INFO_SUCCESS, board));
         } else {
             return ResponseEntity.ok(ResultResponse.of(BOARD_NOT_EXIST, null));
@@ -47,7 +47,6 @@ public class BoardController {
     @GetMapping("")
     public ResponseEntity<ResultResponse> getBoardList(@RequestParam(value = "offset", defaultValue = "0") int offset,
                                                        @RequestParam(value = "limit", defaultValue = "10") int limit) {
-        log.info("paginationRequest: {}, {}", offset, limit);
         Page<List<BoardDetailResponseDTO>> boardList = boardService.getBoardList(offset, limit);
         return ResponseEntity.ok(ResultResponse.of(BOARD_LIST_INFO_SUCCESS, boardList));
     }
@@ -67,10 +66,10 @@ public class BoardController {
         return ResponseEntity.ok(ResultResponse.of(BOARD_INFO_SUCCESS, board));
     }
 
-    @Operation(summary = "게시물 메모 업데이트", description = "게시물 메모를 수정하는 메서드입니다. ")
+    @Operation(summary = "게시물 업데이트", description = "게시물 설명을 수정하는 메서드입니다. ")
     @PatchMapping("/{boardId}")
-    public ResponseEntity<ResultResponse> updateBoardMemo(HttpServletRequest tokenRequest, @PathVariable Long boardId, @RequestBody BoardMemoUpdateRequest updateRequest) {
-        BoardResponseDTO board = boardService.updateBoardMemo(tokenRequest, boardId, updateRequest);
+    public ResponseEntity<ResultResponse> updateBoard(HttpServletRequest tokenRequest, @PathVariable Long boardId, @RequestBody BoardUpdateRequest updateRequest) {
+        BoardResponseDTO board = boardService.updateBoard(tokenRequest, boardId, updateRequest);
         return ResponseEntity.ok(ResultResponse.of(BOARD_MEMO_UPDATE_SUCCESS, board));
     }
 
@@ -79,5 +78,12 @@ public class BoardController {
     public ResponseEntity<ResultResponse> deleteBoard(HttpServletRequest tokenRequest, @PathVariable Long boardId) {
         boardService.deleteBoard(tokenRequest, boardId);
         return ResponseEntity.ok(ResultResponse.of(BOARD_DELETE_SUCCESS));
+    }
+
+    @Operation(summary = "게시물 메모 업데이트", description = "게시물 메모를 수정하는 메서드입니다. ")
+    @PatchMapping("/memo/{boardId}")
+    public ResponseEntity<ResultResponse> updateBoardMemo(HttpServletRequest tokenRequest, @PathVariable Long boardId, @RequestBody BoardMemoUpdateRequest updateRequest) {
+        BoardResponseDTO board = boardService.updateBoardMemo(tokenRequest, boardId, updateRequest);
+        return ResponseEntity.ok(ResultResponse.of(BOARD_MEMO_UPDATE_SUCCESS, board));
     }
 }

--- a/src/main/java/com/Alchive/backend/controller/SolutionController.java
+++ b/src/main/java/com/Alchive/backend/controller/SolutionController.java
@@ -39,7 +39,7 @@ public class SolutionController {
     @Operation(summary = "풀이 삭제", description = "풀이를 삭제하는 메서드입니다.")
     @DeleteMapping("/{solutionId}")
     public ResponseEntity<ResultResponse> deleteSolution(HttpServletRequest tokenRequest, @PathVariable Long solutionId) {
-        SolutionDetailResponseDTO solution = solutionService.deleteSolution(tokenRequest, solutionId);
-        return ResponseEntity.ok(ResultResponse.of(SOLUTION_DELETE_SUCCESS, solution));
+        solutionService.deleteSolution(tokenRequest, solutionId);
+        return ResponseEntity.ok(ResultResponse.of(SOLUTION_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/com/Alchive/backend/controller/UserController.java
+++ b/src/main/java/com/Alchive/backend/controller/UserController.java
@@ -34,9 +34,9 @@ public class UserController {
     }
 
     @Operation(summary = "username 중복 확인 메서드", description = "username 중복을 검사하는 메서드입니다.")
-    @GetMapping("/username/{userName}")
-    public ResponseEntity<ResultResponse> isDuplicateUsername(@PathVariable String userName) {
-        if(userService.isDuplicateUsername(userName)) {
+    @GetMapping("/username/{name}")
+    public ResponseEntity<ResultResponse> isDuplicateUsername(@PathVariable String name) {
+        if (userService.isDuplicateUsername(name)) {
             return ResponseEntity.ok(ResultResponse.of(USER_USERNAME_DUPLICATED, true));
         }
         return ResponseEntity.ok(ResultResponse.of(USER_USERNAME_NOT_DUPLICATED, false));
@@ -52,8 +52,8 @@ public class UserController {
     @Operation(summary = "프로필 수정 메서드", description = "특정 사용자의 프로필 정보를 수정하는 메서드입니다.")
     @PutMapping
     public ResponseEntity<ResultResponse> updateUser(HttpServletRequest request, @RequestBody UserUpdateRequest updateRequest) {
-        userService.updateUserDetail(request, updateRequest);
-        return ResponseEntity.ok(ResultResponse.of(USER_UPDATE_SUCCESS));
+        User user = userService.updateUserDetail(request, updateRequest);
+        return ResponseEntity.ok(ResultResponse.of(USER_UPDATE_SUCCESS, new UserDetailResponseDTO(user)));
     }
 
     @Operation(summary = "사용자 삭제 메서드", description = "특정 사용자를 삭제하는 메서드입니다.")

--- a/src/main/java/com/Alchive/backend/domain/BaseEntity.java
+++ b/src/main/java/com/Alchive/backend/domain/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.Alchive.backend.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "bit(1) default 0")
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/com/Alchive/backend/domain/algorithm/Algorithm.java
+++ b/src/main/java/com/Alchive/backend/domain/algorithm/Algorithm.java
@@ -4,6 +4,7 @@ import com.Alchive.backend.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Builder
 @AllArgsConstructor
@@ -11,6 +12,7 @@ import org.hibernate.annotations.SQLDelete;
 @Getter
 @Entity
 @SQLDelete(sql = "UPDATE algorithm SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "algorithm")
 public class Algorithm extends BaseEntity {
 

--- a/src/main/java/com/Alchive/backend/domain/algorithm/Algorithm.java
+++ b/src/main/java/com/Alchive/backend/domain/algorithm/Algorithm.java
@@ -1,37 +1,23 @@
 package com.Alchive.backend.domain.algorithm;
 
+import com.Alchive.backend.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE algorithm SET is_deleted = true WHERE id = ?")
 @Table(name = "algorithm")
-public class Algorithm {
+public class Algorithm extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
-
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
 
     @Column(name = "name", nullable = false, length = 30)
     private String name;
@@ -39,7 +25,6 @@ public class Algorithm {
     public static Algorithm of(String name) {
         return Algorithm.builder()
                 .name(name)
-                .isDeleted(false)
                 .build();
     }
 

--- a/src/main/java/com/Alchive/backend/domain/algorithmProblem/AlgorithmProblem.java
+++ b/src/main/java/com/Alchive/backend/domain/algorithmProblem/AlgorithmProblem.java
@@ -1,53 +1,38 @@
 package com.Alchive.backend.domain.algorithmProblem;
 
+import com.Alchive.backend.domain.BaseEntity;
 import com.Alchive.backend.domain.algorithm.Algorithm;
 import com.Alchive.backend.domain.problem.Problem;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE algorithm_problem SET is_deleted = true WHERE id = ?")
 @Table(name = "algorithm_problem")
-public class AlgorithmProblem {
+public class AlgorithmProblem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
 
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
-
     @ManyToOne
-    @JoinColumn(name = "algorithmId", nullable = false)
+    @JoinColumn(name = "algorithm_id", nullable = false)
     private Algorithm algorithm;
 
     @ManyToOne
-    @JoinColumn(name = "problemId", nullable = false)
+    @JoinColumn(name = "problem_id", nullable = false)
     private Problem problem;
 
     public static AlgorithmProblem of(Algorithm algorithm, Problem problem) {
         return AlgorithmProblem.builder()
                 .algorithm(algorithm)
                 .problem(problem)
-                .isDeleted(false)
                 .build();
     }
 }

--- a/src/main/java/com/Alchive/backend/domain/algorithmProblem/AlgorithmProblem.java
+++ b/src/main/java/com/Alchive/backend/domain/algorithmProblem/AlgorithmProblem.java
@@ -6,6 +6,7 @@ import com.Alchive.backend.domain.problem.Problem;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Builder
 @AllArgsConstructor
@@ -13,6 +14,7 @@ import org.hibernate.annotations.SQLDelete;
 @Getter
 @Entity
 @SQLDelete(sql = "UPDATE algorithm_problem SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "algorithm_problem")
 public class AlgorithmProblem extends BaseEntity {
 

--- a/src/main/java/com/Alchive/backend/domain/board/Board.java
+++ b/src/main/java/com/Alchive/backend/domain/board/Board.java
@@ -1,47 +1,34 @@
 package com.Alchive.backend.domain.board;
 
+import com.Alchive.backend.domain.BaseEntity;
 import com.Alchive.backend.domain.problem.Problem;
 import com.Alchive.backend.domain.user.User;
 import com.Alchive.backend.dto.request.BoardCreateRequest;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE board SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "board")
-public class Board {
+public class Board extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
 
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Builder.Default
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
-
     @ManyToOne
-    @JoinColumn(name = "problemId", nullable = false)
+    @JoinColumn(name = "problem_id", nullable = false)
     private Problem problem;
 
     @ManyToOne
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(name = "memo")
@@ -65,13 +52,14 @@ public class Board {
                 .build();
     }
 
-    public Board update(String memo) {
+    public Board updateMemo(String memo) {
         this.memo = memo;
         return this;
     }
 
-    public Board softDelete() {
-        this.isDeleted = true;
+    public Board updateDescription(String description) {
+        this.description = description;
         return this;
     }
+
 }

--- a/src/main/java/com/Alchive/backend/domain/problem/Problem.java
+++ b/src/main/java/com/Alchive/backend/domain/problem/Problem.java
@@ -5,6 +5,7 @@ import com.Alchive.backend.dto.request.ProblemCreateRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Builder
 @AllArgsConstructor
@@ -12,6 +13,7 @@ import org.hibernate.annotations.SQLDelete;
 @Getter
 @Entity
 @SQLDelete(sql = "UPDATE problem SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "problem")
 public class Problem extends BaseEntity {
 

--- a/src/main/java/com/Alchive/backend/domain/problem/Problem.java
+++ b/src/main/java/com/Alchive/backend/domain/problem/Problem.java
@@ -1,39 +1,24 @@
 package com.Alchive.backend.domain.problem;
 
+import com.Alchive.backend.domain.BaseEntity;
 import com.Alchive.backend.dto.request.ProblemCreateRequest;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE problem SET is_deleted = true WHERE id = ?")
 @Table(name = "problem")
-public class Problem {
+public class Problem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
-
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Builder.Default
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
 
     @Column(name = "number", nullable = false)
     private int number;

--- a/src/main/java/com/Alchive/backend/domain/sns/Sns.java
+++ b/src/main/java/com/Alchive/backend/domain/sns/Sns.java
@@ -1,42 +1,29 @@
 package com.Alchive.backend.domain.sns;
 
+import com.Alchive.backend.domain.BaseEntity;
 import com.Alchive.backend.domain.user.User;
 import com.Alchive.backend.dto.request.SnsCreateRequest;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Entity
-@Table(name = "sns")
 @Getter
-public class Sns {
+@Entity
+@SQLDelete(sql = "UPDATE sns SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
+@Table(name = "sns")
+public class Sns extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
 
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Builder.Default
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
-
     @ManyToOne
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/Alchive/backend/domain/solution/Solution.java
+++ b/src/main/java/com/Alchive/backend/domain/solution/Solution.java
@@ -1,13 +1,12 @@
 package com.Alchive.backend.domain.solution;
 
+import com.Alchive.backend.domain.BaseEntity;
 import com.Alchive.backend.domain.board.Board;
 import com.Alchive.backend.dto.request.SolutionCreateRequest;
 import com.Alchive.backend.dto.request.SolutionUpdateRequest;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
 
@@ -16,29 +15,17 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE solution SET is_deleted = true WHERE id = ?")
 @Table(name = "solution")
-public class Solution {
+public class Solution extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
 
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Builder.Default
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
-
     @ManyToOne
-    @JoinColumn(name = "boardId", nullable = false)
+    @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
     @Lob
@@ -63,7 +50,7 @@ public class Solution {
     @Column(name = "time")
     private Integer time;
 
-    @Column(name = "submitAt")
+    @Column(name = "submit_at")
     private LocalDateTime submitAt;
 
     public static Solution of(Board board, SolutionCreateRequest solutionRequest) {
@@ -83,10 +70,4 @@ public class Solution {
         this.description = solutionRequest.getDescription();
         return this;
     }
-
-    public Solution softDelete() {
-        this.isDeleted = true;
-        return this;
-    }
-
 }

--- a/src/main/java/com/Alchive/backend/domain/solution/Solution.java
+++ b/src/main/java/com/Alchive/backend/domain/solution/Solution.java
@@ -7,6 +7,7 @@ import com.Alchive.backend.dto.request.SolutionUpdateRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @SQLDelete(sql = "UPDATE solution SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "solution")
 public class Solution extends BaseEntity {
 

--- a/src/main/java/com/Alchive/backend/domain/user/User.java
+++ b/src/main/java/com/Alchive/backend/domain/user/User.java
@@ -1,38 +1,27 @@
 package com.Alchive.backend.domain.user;
 
+import com.Alchive.backend.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE user SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "user")
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "INT")
     private Long id;
-
-    @CreationTimestamp
-    @Column(name = "createdAt", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updatedAt", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @ColumnDefault("false")
-    @Column(name = "isDeleted", nullable = false)
-    private Boolean isDeleted = false;
 
     @Column(name = "email", length = 300, nullable = false)
     private String email;
@@ -43,40 +32,31 @@ public class User {
     @Column(name = "description", length = 2048)
     private String description;
 
-    @Column(name = "autoSave", nullable = false)
+    @Column(name = "auto_save", nullable = false)
     @ColumnDefault("true")
     private Boolean autoSave = true;
 
-    public User(Long userId) {
-        this.id = userId;
+    public User(Long id) {
+        this.id = id;
     }
 
     @Builder // 빌더 패턴 구현
-    public User(String userEmail, String userNickName) {
-        this.email = userEmail;
-        this.name = userNickName;
-        this.createdAt = LocalDateTime.now(); // 현재 시간
+    public User(String email, String name) {
+        this.email = email;
+        this.name = name;
     }
 
     // 단위 테스트용 빌더 패턴 구현
     @Builder(builderMethodName = "userTestBuilder")
-    public User(Long userId, String userEmail, String userNickName) {
-        this.id = userId;
-        this.email = userEmail;
-        this.name = userNickName;
-        this.createdAt = LocalDateTime.now(); // 현재 시간
+    public User(Long id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
     }
 
-    public User update(String userDescription, Boolean autoSave) { // 프로필 수정 시 사용
-        this.description = userDescription;
+    public User update(String description, Boolean autoSave) { // 프로필 수정 시 사용
+        this.description = description;
         this.autoSave = autoSave;
-        this.updatedAt = LocalDateTime.now();
-
-        return this;
-    }
-
-    public User softDelete() {
-        this.isDeleted = true;
         return this;
     }
 }

--- a/src/main/java/com/Alchive/backend/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/com/Alchive/backend/dto/request/BoardUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.Alchive.backend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class BoardUpdateRequest {
+    private final String description;
+
+    @JsonCreator
+    public BoardUpdateRequest(@JsonProperty("description") String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/Alchive/backend/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/Alchive/backend/dto/request/UserCreateRequest.java
@@ -10,7 +10,7 @@ import lombok.*;
 @AllArgsConstructor
 public class UserCreateRequest {
     @NotBlank(message = "유저 이메일은 필수입니다. ")
-    private String userEmail;
+    private String email;
     @NotBlank(message = "유저 이름은 필수입니다. ")
-    private String userName;
+    private String name;
 }

--- a/src/main/java/com/Alchive/backend/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/Alchive/backend/dto/request/UserUpdateRequest.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 public class UserUpdateRequest {
-    private String userDescription;
+    private String description;
     private Boolean autoSave;
 }

--- a/src/main/java/com/Alchive/backend/repository/BoardRepository.java
+++ b/src/main/java/com/Alchive/backend/repository/BoardRepository.java
@@ -15,6 +15,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByProblem_PlatformAndProblem_NumberAndUser_Id(ProblemPlatform platform, int problemNumber, Long userId);
 
 
-    @Query(value = "SELECT * FROM Board WHERE createdAt <= :threeDaysAgo AND status != 'CORRECT' ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    @Query(value = "SELECT * FROM Board WHERE created_at <= :threeDaysAgo AND status != 'CORRECT' ORDER BY RAND() LIMIT 1", nativeQuery = true)
     Board findUnsolvedBoardAddedBefore(@Param("threeDaysAgo") LocalDateTime threeDaysAgo);
 }

--- a/src/main/java/com/Alchive/backend/repository/UserRepository.java
+++ b/src/main/java/com/Alchive/backend/repository/UserRepository.java
@@ -9,9 +9,9 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByEmail(String userEmail);
+    boolean existsByEmail(String email);
 
-    boolean existsByName(String userName);
+    boolean existsByName(String name);
 
-    Optional<User> findByEmail(String userEmail);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/Alchive/backend/service/SolutionService.java
+++ b/src/main/java/com/Alchive/backend/service/SolutionService.java
@@ -35,16 +35,14 @@ public class SolutionService {
         Long userId = tokenService.validateAccessToken(tokenRequest);
         Solution solution = solutionRepository.findById(solutionId).orElseThrow(NotFoundSolutionException::new);
         userService.validateUser(userId, solution.getBoard().getUser().getId());
-        solution.update(solutionRequest);
-        return new SolutionDetailResponseDTO(solutionRepository.save(solution));
+        return new SolutionDetailResponseDTO(solution.update(solutionRequest));
     }
 
     @Transactional
-    public SolutionDetailResponseDTO deleteSolution(HttpServletRequest tokenRequest, Long solutionId) {
+    public void deleteSolution(HttpServletRequest tokenRequest, Long solutionId) {
         Long userId = tokenService.validateAccessToken(tokenRequest);
         Solution solution = solutionRepository.findById(solutionId).orElseThrow(NotFoundSolutionException::new);
         userService.validateUser(userId, solution.getBoard().getUser().getId());
-        solution.softDelete();
-        return new SolutionDetailResponseDTO(solutionRepository.save(solution));
+        solutionRepository.delete(solution);
     }
 }

--- a/src/main/java/com/Alchive/backend/service/UserService.java
+++ b/src/main/java/com/Alchive/backend/service/UserService.java
@@ -23,8 +23,8 @@ public class UserService {
 
     @Transactional
     public UserResponseDTO createUser(UserCreateRequest request) {
-        String email = request.getUserEmail();
-        String username = request.getUserName();
+        String email = request.getEmail();
+        String username = request.getName();
         if (userRepository.existsByEmail(email)) { // 중복 이메일 검사
             throw new UserEmailExistException();
         }
@@ -42,8 +42,8 @@ public class UserService {
         return new UserResponseDTO(user, accessToken, refreshToken);
     }
 
-    public boolean isDuplicateUsername(String userName) {
-        return userRepository.existsByName(userName);
+    public boolean isDuplicateUsername(String name) {
+        return userRepository.existsByName(name);
     }
 
     public User getUserDetail(HttpServletRequest tokenRequest) {
@@ -53,11 +53,11 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserDetail(HttpServletRequest tokenRequest, UserUpdateRequest updateRequest) {
+    public User updateUserDetail(HttpServletRequest tokenRequest, UserUpdateRequest updateRequest) {
         Long userId = tokenService.validateAccessToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(NoSuchUserIdException::new);
-        user.update(updateRequest.getUserDescription(), updateRequest.getAutoSave());
+        return user.update(updateRequest.getDescription(), updateRequest.getAutoSave());
     }
 
     @Transactional
@@ -65,8 +65,7 @@ public class UserService {
         Long userId = tokenService.validateAccessToken(tokenRequest);
         User user = userRepository.findById(userId)
                 .orElseThrow(NoSuchUserIdException::new);
-        user.softDelete();
-        userRepository.save(user);
+        userRepository.delete(user);
     }
 
     public void validateUser(Long userId, Long requestedId) {

--- a/src/test/java/com/Alchive/backend/service/SolutionServiceTest.java
+++ b/src/test/java/com/Alchive/backend/service/SolutionServiceTest.java
@@ -7,6 +7,7 @@ import com.Alchive.backend.domain.solution.Solution;
 import com.Alchive.backend.domain.solution.SolutionLanguage;
 import com.Alchive.backend.domain.solution.SolutionStatus;
 import com.Alchive.backend.dto.request.SolutionCreateRequest;
+import com.Alchive.backend.dto.request.SolutionUpdateRequest;
 import com.Alchive.backend.dto.response.SolutionDetailResponseDTO;
 import com.Alchive.backend.repository.BoardRepository;
 import com.Alchive.backend.repository.SolutionRepository;
@@ -25,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class SolutionServiceTest {
+class SolutionServiceTest {
     @InjectMocks
     private SolutionService solutionService;
 
@@ -40,7 +41,8 @@ public class SolutionServiceTest {
 
     private Board mockBoard;
     private Solution mockSolution;
-    private SolutionCreateRequest mockRequest;
+    private SolutionCreateRequest mockCreateRequest;
+    private SolutionUpdateRequest mockUpdateRequest;
 
     @BeforeEach
     void setUp() {
@@ -57,7 +59,7 @@ public class SolutionServiceTest {
                 .board(mockBoard)
                 .build();
 
-        mockRequest = SolutionCreateRequest.builder()
+        mockCreateRequest = SolutionCreateRequest.builder()
                 .content("Sample content")
                 .language(SolutionLanguage.JAVA)
                 .description("Sample description")
@@ -65,6 +67,10 @@ public class SolutionServiceTest {
                 .memory(128)
                 .time(200)
                 .submitAt(LocalDateTime.now())
+                .build();
+
+        mockUpdateRequest = SolutionUpdateRequest.builder()
+                .description("update description")
                 .build();
     }
 
@@ -74,7 +80,7 @@ public class SolutionServiceTest {
         when(boardRepository.findById(1L)).thenReturn(Optional.of(mockBoard)); // 게시물이 존재하는 경우
         when(solutionRepository.save(any(Solution.class))).thenReturn(mockSolution); // Solution 객체 저장 시 Mock 객체 반환
 
-        SolutionDetailResponseDTO response = solutionService.createSolution(request, 1L, mockRequest);
+        SolutionDetailResponseDTO response = solutionService.createSolution(request, 1L, mockCreateRequest);
 
         assertNotNull(response); // 응답이 null이 아님을 확인
         assertEquals(mockSolution.getId(), response.getId()); // ID가 일치하는지 확인
@@ -88,7 +94,7 @@ public class SolutionServiceTest {
         when(boardRepository.findById(1L)).thenReturn(Optional.empty()); // 게시물이 존재하지 않는 경우
 
         assertThrows(NotFoundBoardException.class, () -> { // NotFoundBoardException이 발생하는지 검증
-            solutionService.createSolution(request, 1L, mockRequest);
+            solutionService.createSolution(request, 1L, mockCreateRequest);
         });
     }
 
@@ -96,9 +102,8 @@ public class SolutionServiceTest {
     @DisplayName("풀이 수정 성공")
     void testUpdateSolution() {
         when(solutionRepository.findById(1L)).thenReturn(Optional.of(mockSolution));
-        when(solutionRepository.save(any(Solution.class))).thenReturn(mockSolution);
 
-        SolutionDetailResponseDTO response = solutionService.updateSolution(request, 1L, mockRequest);
+        SolutionDetailResponseDTO response = solutionService.updateSolution(request, 1L, mockUpdateRequest);
 
         assertNotNull(response);
         assertEquals(mockSolution.getId(), response.getId());
@@ -112,7 +117,7 @@ public class SolutionServiceTest {
         when(solutionRepository.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundSolutionException.class, () -> {
-            solutionService.updateSolution(request, 1L, mockRequest);
+            solutionService.updateSolution(request, 1L, mockUpdateRequest);
         });
     }
 
@@ -122,10 +127,8 @@ public class SolutionServiceTest {
         when(solutionRepository.findById(1L)).thenReturn(Optional.of(mockSolution));
         when(solutionRepository.save(any(Solution.class))).thenReturn(mockSolution);
 
-        SolutionDetailResponseDTO response = solutionService.deleteSolution(request, 1L);
+        solutionService.deleteSolution(request, 1L);
 
-        assertNotNull(response);
-        assertEquals(mockSolution.getId(), response.getId());
         assertTrue(mockSolution.getIsDeleted()); // softDelete가 제대로 동작했는지 확인
         verify(solutionRepository, times(1)).findById(1L);
         verify(solutionRepository, times(1)).save(any(Solution.class));

--- a/src/test/java/com/Alchive/backend/service/UserServiceTest.java
+++ b/src/test/java/com/Alchive/backend/service/UserServiceTest.java
@@ -46,9 +46,9 @@ public class UserServiceTest {
 
         // 테스트용 Builder 패턴을 이용해 userId까지 직접 입력
         user = User.userTestBuilder()
-                .userId(1L)
-                .userEmail("user1@test.com")
-                .userNickName("user1")
+                .id(1L)
+                .email("user1@test.com")
+                .name("user1")
                 .build();
     }
 
@@ -57,11 +57,11 @@ public class UserServiceTest {
     void createUser_success() {
         // given
         UserCreateRequest createRequest = UserCreateRequest.builder()
-                .userEmail(user.getEmail())
-                .userName(user.getName())
+                .email(user.getEmail())
+                .name(user.getName())
                 .build();
 
-        when(userRepository.existsByEmail(createRequest.getUserEmail())).thenReturn(false);
+        when(userRepository.existsByEmail(createRequest.getEmail())).thenReturn(false);
         when(userRepository.save(any(User.class))).thenReturn(user);
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         doNothing().when(tokenService).validateAccessToken(request);
@@ -72,9 +72,9 @@ public class UserServiceTest {
 
         // then
         assertNotNull(returnedUser);
-        assertEquals(user.getId(),returnedUser.getUserId());
-        assertEquals(user.getName(),returnedUser.getUserName());
-        assertEquals(user.getEmail(),returnedUser.getUserEmail());
+        assertEquals(user.getId(), returnedUser.getUserId());
+        assertEquals(user.getName(), returnedUser.getUserName());
+        assertEquals(user.getEmail(), returnedUser.getUserEmail());
     }
 
     @DisplayName("사용자 생성 - 유저 닉네임 중복")
@@ -82,13 +82,13 @@ public class UserServiceTest {
     void createUser_username_exists() {
         // given
         UserCreateRequest createRequest = UserCreateRequest.builder()
-                .userEmail("testEmail@test.com")
-                .userName("duplicatedUserName")
+                .email("testEmail@test.com")
+                .name("duplicatedUserName")
                 .build();
-        when(userService.isDuplicateUsername(createRequest.getUserName())).thenReturn(true);
+        when(userService.isDuplicateUsername(createRequest.getName())).thenReturn(true);
 
         // when
-        boolean returnedAnswer = userService.isDuplicateUsername(createRequest.getUserName());
+        boolean returnedAnswer = userService.isDuplicateUsername(createRequest.getName());
 
         // then
         assertTrue(returnedAnswer);
@@ -99,10 +99,10 @@ public class UserServiceTest {
     void createUser_userEmail_exists() {
         // given
         UserCreateRequest createRequest = UserCreateRequest.builder()
-                .userEmail("duplicatedEmail@test.com")
-                .userName("user1")
+                .email("duplicatedEmail@test.com")
+                .name("user1")
                 .build();
-        when(userRepository.existsByEmail(createRequest.getUserEmail())).thenReturn(true);
+        when(userRepository.existsByEmail(createRequest.getEmail())).thenReturn(true);
 
         // when, then
         assertThrows(UserEmailExistException.class, () -> userService.createUser(createRequest));
@@ -121,9 +121,9 @@ public class UserServiceTest {
 
         // then
         assertNotNull(returnedUser);
-        assertEquals(user.getId(),returnedUser.getId());
-        assertEquals(user.getEmail(),returnedUser.getEmail());
-        assertEquals(user.getName(),returnedUser.getName());
+        assertEquals(user.getId(), returnedUser.getId());
+        assertEquals(user.getEmail(), returnedUser.getEmail());
+        assertEquals(user.getName(), returnedUser.getName());
     }
 
     @DisplayName("프로필 조회 - 존재하지 않는 유저 아이디")
@@ -143,7 +143,7 @@ public class UserServiceTest {
     void updateUser_success() {
         // given
         UserUpdateRequest updateRequest = UserUpdateRequest.builder()
-                .userDescription("updatedUserDescription")
+                .description("updatedUserDescription")
                 .build();
         doNothing().when(tokenService).validateAccessToken(request);
         when(tokenService.validateAccessToken(request)).thenReturn(user.getId());
@@ -151,11 +151,11 @@ public class UserServiceTest {
         when(userRepository.save(any(User.class))).thenReturn(user);
 
         // when
-        userService.updateUserDetail(request,updateRequest);
+        userService.updateUserDetail(request, updateRequest);
 
         // then
         assertNotNull(user);
-        assertEquals(user.getDescription(),"updatedUserDescription");
+        assertEquals(user.getDescription(), "updatedUserDescription");
     }
 
     @DisplayName("사용자 삭제 - 성공")


### PR DESCRIPTION
## Summary

<!-- 작업한 내용을 간단히 작성해주세요. -->

BaseEntity 도입 및 일부 코드 리팩토링

## Description

<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->

1. 도메인의 기본적인 isDeleted, updatedAt, createdAt 를 BaseEntity로 분리
    - 엔티티 어노테이션 칼럼명 스네이크케이스로 변경
    - @ CreatedDate, @ LastModifiedDate 사용해서 생성, 수정일 자동 관리

2. is_deleted 여부 관련 어노테이션 추가
    - @ SQLDelete 로 소프트 딜리트 구현
    - @ Where 조회 시 자동 is_deleted 검사하게 함

3. 업데이트, 삭제 시 save 생략
    - 명시적으로 작성해놓았던 save() 함수 제거

4. api 추가 및 수정
    - board memo 수정만 있고 description 수정 api가 없어서 추가함
    - 유저 description 수정 시 변경된 내용 반환하도록 수정

## Screenshot

<!-- 실행 결과 스크린샷을 올려주세요. -->

## Test Checklist

<!-- 확인해야 할 체크리스트를 작성해주세요. -->

- [x] BaseEntity 적용

코드 변경 사항이 많아서 BaseEntity 적용부터 하고 PR 날립니당 토큰 관련은 새 이슈 파서 하겠음!
