### PR TITLE
refactor: Board controller, service 계층 리팩토링/테스트 코드 추가

### DIFF
--- a/src/main/java/com/Alchive/backend/config/result/ResultCode.java
+++ b/src/main/java/com/Alchive/backend/config/result/ResultCode.java
@@ -32,7 +32,7 @@ public enum ResultCode {
     BOARD_NOT_EXIST("B004", "존재하지 않는 게시물"),
     BOARD_MEMO_UPDATE_SUCCESS("B005", "게시물 메모 수정 성공"),
     BOARD_DELETE_SUCCESS("B006", "게시물 삭제 성공"),
-    BOARD_ALREADY_EXSIST("B007", "존재하는 게시물"),
+    BOARD_ALREADY_EXIST("B007", "존재하는 게시물"),
 
     // SNS
     SNS_INFO_SUCCESS("N001", "소셜 조회 성공"),

--- a/src/main/java/com/Alchive/backend/config/result/ResultCode.java
+++ b/src/main/java/com/Alchive/backend/config/result/ResultCode.java
@@ -32,6 +32,7 @@ public enum ResultCode {
     BOARD_NOT_EXIST("B004", "존재하지 않는 게시물"),
     BOARD_MEMO_UPDATE_SUCCESS("B005", "게시물 메모 수정 성공"),
     BOARD_DELETE_SUCCESS("B006", "게시물 삭제 성공"),
+    BOARD_ALREADY_EXSIST("B007", "존재하는 게시물"),
 
     // SNS
     SNS_INFO_SUCCESS("N001", "소셜 조회 성공"),

--- a/src/main/java/com/Alchive/backend/controller/BoardController.java
+++ b/src/main/java/com/Alchive/backend/controller/BoardController.java
@@ -40,7 +40,7 @@ public class BoardController {
             return ResponseEntity.ok(ResultResponse.of(BOARD_INFO_SUCCESS, board));
         } else {
             return ResponseEntity.ok(ResultResponse.of(BOARD_NOT_EXIST, null));
-        }
+        } // todo: board 저장 여부 반환 메시지 재정의, 중복 제거
     }
 
     @Operation(summary = "게시물 목록 조회", description = "게시물 목록을 조회하는 메서드입니다. ")
@@ -55,7 +55,6 @@ public class BoardController {
     @PostMapping("")
     public ResponseEntity<ResultResponse> createBoard(@AuthenticationPrincipal User user, @RequestBody @Valid BoardCreateRequest boardCreateRequest) {
         BoardResponseDTO board = boardService.createBoard(user, boardCreateRequest);
-//        slackService.sendMessageCreateBoard(boardCreateRequest, board);
         return ResponseEntity.ok(ResultResponse.of(BOARD_CREATE_SUCCESS, board));
     }
 

--- a/src/main/java/com/Alchive/backend/controller/BoardController.java
+++ b/src/main/java/com/Alchive/backend/controller/BoardController.java
@@ -68,17 +68,17 @@ public class BoardController {
         return ResponseEntity.ok(ResultResponse.of(BOARD_MEMO_UPDATE_SUCCESS, board));
     }
 
-    @Operation(summary = "게시물 삭제", description = "게시물을 삭제하는 메서드입니다. ")
-    @DeleteMapping("/{boardId}")
-    public ResponseEntity<ResultResponse> deleteBoard(@AuthenticationPrincipal User user, @PathVariable Long boardId) {
-        boardService.deleteBoard(user, boardId);
-        return ResponseEntity.ok(ResultResponse.of(BOARD_DELETE_SUCCESS));
-    }
-
     @Operation(summary = "게시물 메모 업데이트", description = "게시물 메모를 수정하는 메서드입니다. ")
     @PatchMapping("/memo/{boardId}")
     public ResponseEntity<ResultResponse> updateBoardMemo(@AuthenticationPrincipal User user, @PathVariable Long boardId, @RequestBody BoardMemoUpdateRequest updateRequest) {
         BoardResponseDTO board = boardService.updateBoardMemo(user, boardId, updateRequest);
         return ResponseEntity.ok(ResultResponse.of(BOARD_MEMO_UPDATE_SUCCESS, board));
+    }
+
+    @Operation(summary = "게시물 삭제", description = "게시물을 삭제하는 메서드입니다. ")
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ResultResponse> deleteBoard(@AuthenticationPrincipal User user, @PathVariable Long boardId) {
+        boardService.deleteBoard(user, boardId);
+        return ResponseEntity.ok(ResultResponse.of(BOARD_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/com/Alchive/backend/controller/BoardController.java
+++ b/src/main/java/com/Alchive/backend/controller/BoardController.java
@@ -36,11 +36,7 @@ public class BoardController {
     @PostMapping("/saved")
     public ResponseEntity<ResultResponse> isBoardSaved(@AuthenticationPrincipal User user, @RequestBody @Valid ProblemNumberRequest problemNumberRequest) {
         BoardDetailResponseDTO board = boardService.isBoardSaved(user, problemNumberRequest);
-        if (board != null) {
-            return ResponseEntity.ok(ResultResponse.of(BOARD_INFO_SUCCESS, board));
-        } else {
-            return ResponseEntity.ok(ResultResponse.of(BOARD_NOT_EXIST, null));
-        } // todo: board 저장 여부 반환 메시지 재정의, 중복 제거
+        return ResponseEntity.ok(ResultResponse.of(boardService.boardSavedStatus(board), board));
     }
 
     @Operation(summary = "게시물 목록 조회", description = "게시물 목록을 조회하는 메서드입니다. ")

--- a/src/main/java/com/Alchive/backend/service/BoardService.java
+++ b/src/main/java/com/Alchive/backend/service/BoardService.java
@@ -3,6 +3,7 @@ package com.Alchive.backend.service;
 import com.Alchive.backend.config.error.exception.board.NotFoundBoardException;
 import com.Alchive.backend.config.error.exception.problem.NotFoundProblemException;
 import com.Alchive.backend.config.result.ResultCode;
+import com.Alchive.backend.config.result.ResultResponse;
 import com.Alchive.backend.domain.algorithm.Algorithm;
 import com.Alchive.backend.domain.algorithmProblem.AlgorithmProblem;
 import com.Alchive.backend.domain.board.Board;
@@ -45,7 +46,7 @@ public class BoardService {
 
     public ResultCode boardSavedStatus(BoardDetailResponseDTO board) {
         if (board != null) {
-            return ResultCode.BOARD_ALREADY_EXSIST;
+            return ResultCode.BOARD_ALREADY_EXIST;
         }
         return ResultCode.BOARD_NOT_EXIST;
     }
@@ -142,8 +143,7 @@ public class BoardService {
         }
     }
 
-    @Transactional
-    public void createAlgorithm(String algorithmName) {
+    private void createAlgorithm(String algorithmName) {
         if (algorithmRepository.existsByName(algorithmName)) {
             return;
         }

--- a/src/main/java/com/Alchive/backend/service/BoardService.java
+++ b/src/main/java/com/Alchive/backend/service/BoardService.java
@@ -16,7 +16,6 @@ import com.Alchive.backend.dto.response.ProblemResponseDTO;
 import com.Alchive.backend.dto.response.SolutionResponseDTO;
 import com.Alchive.backend.repository.*;
 import jakarta.transaction.Transactional;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -39,60 +38,42 @@ public class BoardService {
     private final SolutionRepository solutionRepository;
     private final UserService userService;
 
-    private BoardDetailResponseDTO toBoardDetailResponseDTO(Board board) {
-        BoardResponseDTO boardResponseDTO = new BoardResponseDTO(board);
-
-        // 문제 정보
-        Long problemId = board.getProblem().getId();
-        Problem problem = problemRepository.findById(problemId)
-                .orElseThrow(NotFoundProblemException::new);
-        ProblemResponseDTO problemResponseDTO = new ProblemResponseDTO(problem, getProblemAlgorithms(problemId));
-
-        // 풀이 정보
-        List<SolutionResponseDTO> solutions = getSolutions(board.getId());
-
-        // DTO로 묶어서 반환
-        return new BoardDetailResponseDTO(boardResponseDTO, problemResponseDTO, solutions);
-    }
-
-    // Board 저장 여부 구현
     public BoardDetailResponseDTO isBoardSaved(User user, ProblemNumberRequest problemNumberRequest) {
         Optional<Board> board = boardRepository.findByProblem_PlatformAndProblem_NumberAndUser_Id(problemNumberRequest.getPlatform(), problemNumberRequest.getProblemNumber(), user.getId());
         return board.map(this::toBoardDetailResponseDTO).orElse(null);
+    }
+
+    public ResultCode boardSavedStatus(BoardDetailResponseDTO board) {
+        if (board != null) {
+            return ResultCode.BOARD_ALREADY_EXSIST;
+        }
+        return ResultCode.BOARD_NOT_EXIST;
     }
 
     public Page<List<BoardDetailResponseDTO>> getBoardList(int offset, int limit) {
         Pageable pageable = PageRequest.of(offset, limit);
         Page<Board> boardPage = boardRepository.findAll(pageable);
 
-        // Board를 BoardDetailResponseDTO로 변환
         List<BoardDetailResponseDTO> boardList = boardPage.getContent().stream()
                 .map(this::toBoardDetailResponseDTO)
                 .toList();
 
-        // 변환된 리스트를 새로운 Page 객체로 감싸서 반환
         return new PageImpl<>(List.of(boardList), pageable, boardPage.getTotalElements());
     }
 
-    // 게시물 메서드
-    @Transactional
-    public BoardResponseDTO createBoard(User user, BoardCreateRequest boardCreateRequest) {
-        ProblemCreateRequest problemCreateRequest = boardCreateRequest.getProblemCreateRequest();
-        // 문제 정보 저장 여부 확인
-        if (!problemRepository.existsByNumberAndPlatform(problemCreateRequest.getNumber(), problemCreateRequest.getPlatform())) {
-            // 문제가 저장되지 않은 경우
-            createProblem(problemCreateRequest);
-        }
-        Problem problem = problemRepository.findByNumberAndPlatform(problemCreateRequest.getNumber(), problemCreateRequest.getPlatform());
-        Board board = Board.of(problem, user, boardCreateRequest);
-        return new BoardResponseDTO(boardRepository.save(board));
-    }
-
     public BoardDetailResponseDTO getBoardDetail(Long boardId) {
-        // 게시물 정보
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(NotFoundBoardException::new);
         return toBoardDetailResponseDTO(board);
+    }
+
+    @Transactional
+    public BoardResponseDTO createBoard(User user, BoardCreateRequest boardCreateRequest) {
+        ProblemCreateRequest problemCreateRequest = boardCreateRequest.getProblemCreateRequest();
+        createProblem(problemCreateRequest);
+        Problem problem = problemRepository.findByNumberAndPlatform(problemCreateRequest.getNumber(), problemCreateRequest.getPlatform());
+        Board board = Board.of(problem, user, boardCreateRequest);
+        return new BoardResponseDTO(boardRepository.save(board));
     }
 
     @Transactional
@@ -104,14 +85,6 @@ public class BoardService {
     }
 
     @Transactional
-    public void deleteBoard(User user, Long boardId) {
-        Board board = boardRepository.findById(boardId)
-                .orElseThrow(NotFoundBoardException::new);
-        userService.validateUser(user.getId(), board.getUser().getId());
-        boardRepository.delete(board);
-    }
-
-    @Transactional
     public BoardResponseDTO updateBoardMemo(User user, Long boardId, BoardMemoUpdateRequest updateRequest) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(NotFoundBoardException::new);
@@ -119,47 +92,68 @@ public class BoardService {
         return new BoardResponseDTO(board.updateMemo(updateRequest.getMemo()));
     }
 
-    // 문제 메서드
     @Transactional
-    public void createProblem(ProblemCreateRequest problemCreateRequest) {
-        Problem problem = problemRepository.save(Problem.of(problemCreateRequest));
-        List<String> algorithms = problemCreateRequest.getAlgorithms();
-
-        for (String algorithmName : algorithms) {
-            // 알고리즘 저장 여부 확인
-            if (!algorithmRepository.existsByName(algorithmName)) {
-                // 알고리즘이 저장되지 않은 경우
-                createAlgorithm(algorithmName);
-            }
-            Algorithm algorithm = algorithmRepository.findByName(algorithmName);
-            // Algorithm - Problem 연결
-            AlgorithmProblem algorithmProblem = AlgorithmProblem.of(algorithm, problem);
-            algorithmProblemRepository.save(algorithmProblem);
-        }
+    public void deleteBoard(User user, Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(NotFoundBoardException::new);
+        userService.validateUser(user.getId(), board.getUser().getId());
+        boardRepository.delete(board);
     }
 
-    public List<String> getProblemAlgorithms(Long problemId) {
-        return algorithmProblemRepository.findAlgorithmNamesByProblemId(problemId);
+    private BoardDetailResponseDTO toBoardDetailResponseDTO(Board board) {
+        BoardResponseDTO boardResponseDTO = new BoardResponseDTO(board);
+        ProblemResponseDTO problemResponseDTO = getBoardProblem(board);
+        List<SolutionResponseDTO> solutions = getBoardSolutions(board.getId());
+
+        return new BoardDetailResponseDTO(boardResponseDTO, problemResponseDTO, solutions);
     }
 
-    // 알고리즘 메서드
-    @Transactional
-    public void createAlgorithm(String name) {
-        Algorithm newAlgorithm = Algorithm.of(name);
-        algorithmRepository.save(newAlgorithm);
+    private ProblemResponseDTO getBoardProblem(Board board) {
+        Long problemId = board.getProblem().getId();
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(NotFoundProblemException::new);
+        return new ProblemResponseDTO(problem, getProblemAlgorithms(problemId));
     }
 
-    public List<SolutionResponseDTO> getSolutions(Long boardId) {
+    public List<SolutionResponseDTO> getBoardSolutions(Long boardId) {
         List<Solution> solutions = solutionRepository.findAllByBoard_Id(boardId);
         return solutions.stream()
                 .map(SolutionResponseDTO::new)
                 .toList();
     }
 
-    public ResultCode boardSavedStatus(BoardDetailResponseDTO board) {
-        if (board != null) {
-            return ResultCode.BOARD_ALREADY_EXSIST;
+    public List<String> getProblemAlgorithms(Long problemId) {
+        return algorithmProblemRepository.findAlgorithmNamesByProblemId(problemId);
+    }
+
+    @Transactional
+    public void createProblem(ProblemCreateRequest problemCreateRequest) {
+        if (problemRepository.existsByNumberAndPlatform(problemCreateRequest.getNumber(), problemCreateRequest.getPlatform())) {
+            return;
         }
-        return ResultCode.BOARD_NOT_EXIST;
+        Problem problem = problemRepository.save(Problem.of(problemCreateRequest));
+        connectProblemAlgorithm(problem, problemCreateRequest.getAlgorithms());
+    }
+
+    private void connectProblemAlgorithm(Problem problem, List<String> algorithms) {
+        for (String algorithmName : algorithms) {
+            createAlgorithm(algorithmName);
+            createAlgorithmProblem(algorithmName, problem);
+        }
+    }
+
+    @Transactional
+    public void createAlgorithm(String algorithmName) {
+        if (algorithmRepository.existsByName(algorithmName)) {
+            return;
+        }
+        Algorithm newAlgorithm = Algorithm.of(algorithmName);
+        algorithmRepository.save(newAlgorithm);
+    }
+
+    private void createAlgorithmProblem(String algorithmName, Problem problem) {
+        Algorithm algorithm = algorithmRepository.findByName(algorithmName);
+        AlgorithmProblem algorithmProblem = AlgorithmProblem.of(algorithm, problem);
+        algorithmProblemRepository.save(algorithmProblem);
     }
 }

--- a/src/main/java/com/Alchive/backend/service/BoardService.java
+++ b/src/main/java/com/Alchive/backend/service/BoardService.java
@@ -2,6 +2,7 @@ package com.Alchive.backend.service;
 
 import com.Alchive.backend.config.error.exception.board.NotFoundBoardException;
 import com.Alchive.backend.config.error.exception.problem.NotFoundProblemException;
+import com.Alchive.backend.config.result.ResultCode;
 import com.Alchive.backend.domain.algorithm.Algorithm;
 import com.Alchive.backend.domain.algorithmProblem.AlgorithmProblem;
 import com.Alchive.backend.domain.board.Board;
@@ -15,6 +16,7 @@ import com.Alchive.backend.dto.response.ProblemResponseDTO;
 import com.Alchive.backend.dto.response.SolutionResponseDTO;
 import com.Alchive.backend.repository.*;
 import jakarta.transaction.Transactional;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -152,5 +154,12 @@ public class BoardService {
         return solutions.stream()
                 .map(SolutionResponseDTO::new)
                 .toList();
+    }
+
+    public ResultCode boardSavedStatus(BoardDetailResponseDTO board) {
+        if (board != null) {
+            return ResultCode.BOARD_ALREADY_EXSIST;
+        }
+        return ResultCode.BOARD_NOT_EXIST;
     }
 }

--- a/src/test/java/com/Alchive/backend/controller/BoardControllerTest.java
+++ b/src/test/java/com/Alchive/backend/controller/BoardControllerTest.java
@@ -1,0 +1,89 @@
+package com.Alchive.backend.controller;
+
+import com.Alchive.backend.config.result.ResultResponse;
+import com.Alchive.backend.domain.board.Board;
+import com.Alchive.backend.domain.board.BoardStatus;
+import com.Alchive.backend.domain.problem.Problem;
+import com.Alchive.backend.domain.problem.ProblemDifficulty;
+import com.Alchive.backend.domain.problem.ProblemPlatform;
+import com.Alchive.backend.domain.user.User;
+import com.Alchive.backend.dto.request.ProblemNumberRequest;
+import com.Alchive.backend.dto.response.BoardDetailResponseDTO;
+import com.Alchive.backend.dto.response.BoardResponseDTO;
+import com.Alchive.backend.dto.response.ProblemResponseDTO;
+import com.Alchive.backend.service.BoardService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.Alchive.backend.config.result.ResultCode.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BoardControllerTest {
+    @InjectMocks
+    private BoardController sut;
+    @Mock
+    private BoardService boardService;
+    private Board board;
+    private Problem problem;
+    private User user;
+    private List<String> algorithms = Arrays.asList("BFS", "DFS");
+
+    private long problemId = 1L;
+    private int problemNumber = 1;
+    private String problemTitle = "testProblem";
+    private String problemContent = "this is test problem's content";
+    private String problemUrl = "https://test/problem/1";
+    private ProblemDifficulty problemDifficulty = ProblemDifficulty.LEVEL0;
+    private ProblemPlatform problemPlatform = ProblemPlatform.BAEKJOON;
+    private long userId = 1L;
+    private String userEmail = "testUser@test.com";
+    private String userName = "testUsername";
+    private long boardId = 1L;
+    private String boardMemo = "test problem's memo";
+    private BoardStatus boardStatus = BoardStatus.CORRECT;
+    private String boardDescription = "test problem's description";
+    @BeforeEach
+
+    public void setUp() {
+        problem = new Problem(problemId, problemNumber, problemTitle, problemContent, problemUrl, problemDifficulty, problemPlatform);
+        user = new User(userId, userEmail, userName);
+        board = new Board(boardId, problem, user, boardMemo, boardStatus, boardDescription);
+    }
+
+    @DisplayName("게시물 저장 여부 조회 - 이미 존재하는 문제")
+    @Test
+    public void existBoard() {
+        BoardDetailResponseDTO response = new BoardDetailResponseDTO(new BoardResponseDTO(board), new ProblemResponseDTO(problem, algorithms), new ArrayList<>());
+        when(boardService.isBoardSaved(any(User.class), any(ProblemNumberRequest.class))).thenReturn(response);
+        when(boardService.boardSavedStatus(response)).thenReturn(BOARD_ALREADY_EXSIST);
+
+        ResponseEntity<ResultResponse> result = sut.isBoardSaved(user, new ProblemNumberRequest(problemPlatform, problemNumber));
+
+        Assertions.assertEquals(BOARD_ALREADY_EXSIST.getMessage(), result.getBody().getMessage());
+    }
+
+    @DisplayName("게시물 저장 여부 조회 - 존재하지 않는 문제")
+    @Test
+    public void newBoard() {
+        when(boardService.isBoardSaved(any(User.class), any(ProblemNumberRequest.class))).thenReturn(null);
+        when(boardService.boardSavedStatus(nullable(BoardDetailResponseDTO.class))).thenReturn(BOARD_NOT_EXIST);
+
+        ResponseEntity<ResultResponse> result = sut.isBoardSaved(user, new ProblemNumberRequest(problemPlatform, problemNumber));
+
+        Assertions.assertEquals(BOARD_NOT_EXIST.getMessage(), result.getBody().getMessage());
+    }
+}

--- a/src/test/java/com/Alchive/backend/controller/BoardControllerTest.java
+++ b/src/test/java/com/Alchive/backend/controller/BoardControllerTest.java
@@ -69,11 +69,11 @@ public class BoardControllerTest {
     public void existBoard() {
         BoardDetailResponseDTO response = new BoardDetailResponseDTO(new BoardResponseDTO(board), new ProblemResponseDTO(problem, algorithms), new ArrayList<>());
         when(boardService.isBoardSaved(any(User.class), any(ProblemNumberRequest.class))).thenReturn(response);
-        when(boardService.boardSavedStatus(response)).thenReturn(BOARD_ALREADY_EXSIST);
+        when(boardService.boardSavedStatus(response)).thenReturn(BOARD_ALREADY_EXIST);
 
         ResponseEntity<ResultResponse> result = sut.isBoardSaved(user, new ProblemNumberRequest(problemPlatform, problemNumber));
 
-        Assertions.assertEquals(BOARD_ALREADY_EXSIST.getMessage(), result.getBody().getMessage());
+        Assertions.assertEquals(BOARD_ALREADY_EXIST.getMessage(), result.getBody().getMessage());
     }
 
     @DisplayName("게시물 저장 여부 조회 - 존재하지 않는 문제")

--- a/src/test/java/com/Alchive/backend/service/BoardServiceTest.java
+++ b/src/test/java/com/Alchive/backend/service/BoardServiceTest.java
@@ -1,0 +1,167 @@
+package com.Alchive.backend.service;
+
+import com.Alchive.backend.config.error.exception.token.UnmatchedUserIdException;
+import com.Alchive.backend.domain.algorithm.Algorithm;
+import com.Alchive.backend.domain.algorithmProblem.AlgorithmProblem;
+import com.Alchive.backend.domain.board.Board;
+import com.Alchive.backend.domain.board.BoardStatus;
+import com.Alchive.backend.domain.problem.Problem;
+import com.Alchive.backend.domain.problem.ProblemDifficulty;
+import com.Alchive.backend.domain.problem.ProblemPlatform;
+import com.Alchive.backend.domain.solution.Solution;
+import com.Alchive.backend.domain.user.User;
+import com.Alchive.backend.dto.request.BoardCreateRequest;
+import com.Alchive.backend.dto.request.BoardMemoUpdateRequest;
+import com.Alchive.backend.dto.request.ProblemCreateRequest;
+import com.Alchive.backend.dto.request.ProblemNumberRequest;
+import com.Alchive.backend.dto.response.BoardDetailResponseDTO;
+import com.Alchive.backend.dto.response.BoardResponseDTO;
+import com.Alchive.backend.repository.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class BoardServiceTest {
+    @InjectMocks
+    private BoardService sut;
+    @Mock
+    private BoardRepository boardRepository;
+    @Mock
+    private ProblemRepository problemRepository;
+    @Mock
+    private AlgorithmRepository algorithmRepository;
+    @Mock
+    private AlgorithmProblemRepository algorithmProblemRepository;
+    @Mock
+    private SolutionRepository solutionRepository;
+    @Mock
+    private UserService userService;
+
+    private Board board;
+    private Problem problem;
+    private User user;
+    private List<String> algorithms = Arrays.asList("BFS", "DFS");
+
+    private long problemId = 1L;
+    private int problemNumber = 1;
+    private String problemTitle = "testProblem";
+    private String problemContent = "this is test problem's content";
+    private String problemUrl = "https://test/problem/1";
+    private ProblemDifficulty problemDifficulty = ProblemDifficulty.LEVEL0;
+    private ProblemPlatform problemPlatform = ProblemPlatform.BAEKJOON;
+    private long userId = 1L;
+    private String userEmail = "testUser@test.com";
+    private String userName = "testUsername";
+    private long boardId = 1L;
+    private String boardMemo = "test problem's memo";
+    private BoardStatus boardStatus = BoardStatus.CORRECT;
+    private String boardDescription = "test problem's description";
+    @BeforeEach
+
+    public void setUp() {
+        problem = new Problem(problemId, problemNumber, problemTitle, problemContent, problemUrl, problemDifficulty, problemPlatform);
+        user = new User(userId, userEmail, userName);
+        board = new Board(boardId, problem, user, boardMemo, boardStatus, boardDescription);
+    }
+
+//    @DisplayName("게시물, 문제, 풀이 묶어서 반환 - 성공")
+//    @Test
+//    public void toBoardSolutionDtoSuccess() {
+//        when(problemRepository.findById(problemId)).thenReturn(Optional.ofNullable(problem));
+//        when(algorithmProblemRepository.findAlgorithmNamesByProblemId(problemId)).thenReturn(algorithms);
+//        when(solutionRepository.findAllByBoard_Id(boardId)).thenReturn(new ArrayList<>());
+//    }
+
+    @DisplayName("문제 저장 여부 - 참")
+    @Test
+    public void isBoardSavedTrue() {
+        when(boardRepository.findByProblem_PlatformAndProblem_NumberAndUser_Id(problemPlatform, problemNumber, userId)).thenReturn(Optional.ofNullable(board));
+
+        when(problemRepository.findById(problemId)).thenReturn(Optional.ofNullable(problem));
+        when(algorithmProblemRepository.findAlgorithmNamesByProblemId(problemId)).thenReturn(algorithms);
+        when(solutionRepository.findAllByBoard_Id(boardId)).thenReturn(new ArrayList<>());
+        ProblemNumberRequest request = new ProblemNumberRequest(problemPlatform, problemNumber);
+
+        BoardDetailResponseDTO result = sut.isBoardSaved(user, request);
+
+        Assertions.assertEquals(boardMemo, result.getBoard().getMemo());
+        Assertions.assertEquals(0, result.getSolutions().size());
+        Assertions.assertEquals(2, result.getProblem().getAlgorithms().size());
+    }
+
+    @DisplayName("문제 저장 여부 - 거짓")
+    @Test
+    public void isBoardSavedFalse() {
+        when(boardRepository.findByProblem_PlatformAndProblem_NumberAndUser_Id(problemPlatform, problemNumber, userId)).thenReturn(Optional.empty());
+        ProblemNumberRequest request = new ProblemNumberRequest(problemPlatform, problemNumber);
+
+        BoardDetailResponseDTO result = sut.isBoardSaved(user, request);
+
+        Assertions.assertEquals(null, result);
+    }
+
+    @DisplayName("게시물 저장 - 이미 존재하는 문제")
+    @Test
+    public void createBoardWithExistProblem() {
+        when(problemRepository.existsByNumberAndPlatform(problemNumber, problemPlatform)).thenReturn(true);
+        when(problemRepository.findByNumberAndPlatform(problemNumber, problemPlatform)).thenReturn(problem);
+        when(boardRepository.save(any(Board.class))).thenReturn(board);
+        ProblemCreateRequest request1 = new ProblemCreateRequest(problemNumber, problemTitle, problemContent, problemUrl, problemDifficulty, problemPlatform, algorithms);
+        BoardCreateRequest request = new BoardCreateRequest(request1, boardMemo, boardDescription, boardStatus);
+
+        BoardResponseDTO result = sut.createBoard(user, request);
+
+        Assertions.assertEquals(boardMemo, result.getMemo());
+        Assertions.assertEquals(boardStatus, result.getStatus());
+        Assertions.assertEquals(boardDescription, result.getDescription());
+    }
+
+    @DisplayName("문제 생성 - 성공")
+    @Test
+    public void createProblemSuccess() {
+        when(problemRepository.save(any(Problem.class))).thenReturn(problem);
+        when(algorithmRepository.save(any(Algorithm.class))).thenReturn(Algorithm.of("algorithm"));
+        when(algorithmRepository.findByName(any(String.class))).thenReturn(Algorithm.of("algorithm"));
+        AlgorithmProblem algorithmProblem = new AlgorithmProblem(1L, Algorithm.of("algorithm"), problem);
+        when(algorithmProblemRepository.save(any(AlgorithmProblem.class))).thenReturn(algorithmProblem);
+        ProblemCreateRequest request = new ProblemCreateRequest(problemNumber, problemTitle, problemContent, problemUrl, problemDifficulty, problemPlatform, algorithms);
+
+        sut.createProblem(request);
+    }
+
+    @DisplayName("게시물 수정 - 작성자가 수정")
+    @Test
+    public void updateBoardByAuthor() {
+        when(boardRepository.findById(boardId)).thenReturn(Optional.ofNullable(board));
+        doNothing().when(userService).validateUser(any(Long.class), any(Long.class));
+        String newMemo = "new Memo";
+        BoardMemoUpdateRequest request = new BoardMemoUpdateRequest(newMemo);
+
+        sut.updateBoardMemo(user, boardId, request);
+    }
+
+    @DisplayName("게시물 수정 - 작성자가 아닌 사람이 수정")
+    @Test
+    public void updateBoardByNonAuthor() {
+        when(boardRepository.findById(boardId)).thenReturn(Optional.ofNullable(board));
+        doCallRealMethod().when(userService).validateUser(anyLong(), anyLong());
+        User newUser = new User(2L, "newUser@test.com", "newUser");
+        BoardMemoUpdateRequest request = new BoardMemoUpdateRequest("new Memo");
+
+        Assertions.assertThrows(UnmatchedUserIdException.class, () -> sut.updateBoardMemo(newUser, boardId, request));
+    }
+}

--- a/src/test/java/com/Alchive/backend/service/BoardServiceTest.java
+++ b/src/test/java/com/Alchive/backend/service/BoardServiceTest.java
@@ -129,18 +129,37 @@ public class BoardServiceTest {
         Assertions.assertEquals(boardDescription, result.getDescription());
     }
 
+    @DisplayName("게시물 저장 - 새로운 문제")
+    @Test
+    public void createBoardWithNewProblem() {
+        when(problemRepository.existsByNumberAndPlatform(problemNumber, problemPlatform)).thenReturn(false);
+        when(problemRepository.save(any(Problem.class))).thenReturn(problem);
+        when(algorithmRepository.existsByName(anyString())).thenReturn(true);
+        when(algorithmRepository.findByName(anyString())).thenReturn(new Algorithm(1L, "BFS"));
+        when(problemRepository.findByNumberAndPlatform(problemNumber, problemPlatform)).thenReturn(problem);
+        when(boardRepository.save(any(Board.class))).thenReturn(board);
+        ProblemCreateRequest request1 = new ProblemCreateRequest(problemNumber, problemTitle, problemContent, problemUrl, problemDifficulty, problemPlatform, algorithms);
+        BoardCreateRequest request = new BoardCreateRequest(request1, boardMemo, boardDescription, boardStatus);
+
+        sut.createBoard(user, request);
+    }
+
     @DisplayName("문제 생성 - 성공")
     @Test
     public void createProblemSuccess() {
+        when(problemRepository.existsByNumberAndPlatform(anyInt(), any(ProblemPlatform.class))).thenReturn(false);
         when(problemRepository.save(any(Problem.class))).thenReturn(problem);
-        when(algorithmRepository.save(any(Algorithm.class))).thenReturn(Algorithm.of("algorithm"));
+        when(algorithmRepository.existsByName(anyString())).thenReturn(true);
         when(algorithmRepository.findByName(any(String.class))).thenReturn(Algorithm.of("algorithm"));
         AlgorithmProblem algorithmProblem = new AlgorithmProblem(1L, Algorithm.of("algorithm"), problem);
         when(algorithmProblemRepository.save(any(AlgorithmProblem.class))).thenReturn(algorithmProblem);
+
         ProblemCreateRequest request = new ProblemCreateRequest(problemNumber, problemTitle, problemContent, problemUrl, problemDifficulty, problemPlatform, algorithms);
 
         sut.createProblem(request);
     }
+
+
 
     @DisplayName("게시물 수정 - 작성자가 수정")
     @Test

--- a/src/test/java/com/Alchive/backend/service/BoardServiceTest.java
+++ b/src/test/java/com/Alchive/backend/service/BoardServiceTest.java
@@ -8,7 +8,6 @@ import com.Alchive.backend.domain.board.BoardStatus;
 import com.Alchive.backend.domain.problem.Problem;
 import com.Alchive.backend.domain.problem.ProblemDifficulty;
 import com.Alchive.backend.domain.problem.ProblemPlatform;
-import com.Alchive.backend.domain.solution.Solution;
 import com.Alchive.backend.domain.user.User;
 import com.Alchive.backend.dto.request.BoardCreateRequest;
 import com.Alchive.backend.dto.request.BoardMemoUpdateRequest;


### PR DESCRIPTION
## Summary

<!-- 작업한 내용을 간단히 작성해주세요. -->
- Board controller, service 계층 리팩토링
- Board service 계층 테스트코드 추가
## Description
### 리팩토링
- controller
  - 게시물 저장 여부 확인 메서드: 중복 제거, 결과 코드 변경 
- service
  - 메서드 추상화 레벨별 분리
  - 들여쓰기 최대 1번으로 제한
  - 메서드 순서 변경: 핵심 메서드 상단, 호출되는 메서드 순으로 하단

### 테스트 코드
- controller
  - 게시물 저장 여부 확인 반환만 테스트
- service
  - 레포지토리 조회 등 서비스 로직이 거의 없는 메서드 제외하고 테스트 작성
<!-- 작업한 내용을 자세히 작성해주세요. : 변경된 코드 등 -->

## Screenshot

<!-- 실행 결과 스크린샷을 올려주세요. -->

## Test Checklist

<!-- 확인해야 할 체크리스트를 작성해주세요. -->

- [ ] 체크리스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 게시물이 이미 존재할 때의 상태 메시지가 추가되었습니다.

- **리팩터링**
	- 게시물 상세 조회, 문제 및 알고리즘 처리, 게시물 상태 확인 로직이 더 작은 메서드로 분리되어 코드 구조가 개선되었습니다.
	- 게시물 생성 및 문제 생성 시 존재 여부 확인 로직이 내부로 이동하여 동작이 간소화되었습니다.

- **테스트**
	- 게시물 컨트롤러와 서비스에 대한 단위 테스트가 추가되어 게시물 존재 여부, 생성, 메모 수정 등 주요 기능의 동작이 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->